### PR TITLE
Fix remote for audioflingerglue

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -18,7 +18,7 @@
 
   <project path="hybris/hybris-boot" name="mer-hybris/hybris-boot" remote="github" revision="master" />
   <project path="hybris/mer-kernel-check" name="mer-hybris/mer-kernel-check" remote="github" revision="master" />
-  <project path="external/audioflingerglue" name="mer-hybris/audioflingerglue" revision="master" />
+  <project path="external/audioflingerglue" name="mer-hybris/audioflingerglue" remote="github" revision="master" />
 
   <project path="external/busybox" name="mer-hybris/android_external_busybox" remote="github" revision="hybris-aosp-5.1.0_r5" />
 


### PR DESCRIPTION
default remote is "aosp" on this branch.