### PR TITLE
Update manifest

### DIFF
--- a/tagged-manifest.xml
+++ b/tagged-manifest.xml
@@ -19,13 +19,13 @@
   <project name="android_frameworks_base" path="frameworks/base" remote="sony-patches" revision="de9587cbab4f17c7744e7ef721c54aad9680d0f6" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_frameworks_native" path="frameworks/native" remote="hybris-patches" revision="eb62b481f713c3a3c5d32a2ece78fa45b9537e46" upstream="hybris-sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_hardware_broadcom_libbt" path="hardware/broadcom/libbt" remote="sony-patches" revision="97490d1923dc459a7502c9f488d55a8c4577caf7" upstream="sony-aosp-6.0.1_r80-20170902"/>
-  <project name="android_hardware_qcom_audio" path="hardware/qcom/audio" remote="sony-patches" revision="d287a046899d47a60c9728946982f65e0b85ceb4" upstream="sony-aosp-6.0.1_r80-20170902"/>
+  <project name="android_hardware_qcom_audio" path="hardware/qcom/audio" remote="sony-patches" revision="24be7b102d897f02824d6a326adc7c52ae21b42e" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_hardware_qcom_display" path="hardware/qcom/display" remote="sony-patches" revision="4101df8814dcffe665146d1f9611fb08fe7076f6" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_hardware_qcom_gps" path="hardware/qcom/gps" remote="sony-patches" revision="4d71e2437811266093c31cab4c4da7d081f68176" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_hardware_qcom_keymaster" path="hardware/qcom/keymaster" remote="sony-patches" revision="140e47c0deac29b4fe12408f450ba8200aa469bb" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_hardware_qcom_media" path="hardware/qcom/media" remote="sony-patches" revision="c35f8b426620c458c94048e55a884a9c0b91b1e4" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_hardware_ril" path="hardware/ril" remote="sony-patches" revision="6522613603aa556b0794b2d1eacd5934f5110f01" upstream="sony-aosp-6.0.1_r80-20170902"/>
-  <project name="android_kernel_sony_msm" path="kernel/sony/msm" remote="hybris-patches" revision="005c3d7aeb6d2cc028e5aa415e3413f48e247b15" upstream="hybris-sony-aosp-6.0.1_r80-20170902"/>
+  <project name="android_kernel_sony_msm" path="kernel/sony/msm" remote="hybris-patches" revision="913a4ff3b91ad886165cb56055d2a93392cc8c9e" upstream="hybris-sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_system_core" path="system/core" remote="hybris-patches" revision="0dc4bd1840d1a2fbd88b363ea375d880bdd8c31b" upstream="hybris-sony-aosp-6.0.1_r80-20170902"/>
   <project name="camera" path="hardware/qcom/camera" remote="sony" revision="b66cda07a10d0ff2b043f6d391d62d938a1cf203" upstream="aosp/LA.BR.1.3.3_rb2.14"/>
   <project name="device-sony-common" path="device/sony/common" remote="hybris-patches" revision="da354ad31d8fecdd63a66713da0566d0f6856106" upstream="hybris-sony-aosp-6.0.1_r80-20170902"/>


### PR DESCRIPTION
[kernel_sony_msm] Upstream patch for CVE-2017-1000251. JB#39909
[hardware_qcom_audio] Reset primary output when closing stream.

Change-Id: Ibd77949fbed97494d32e797525788e107f13d2a2
Signed-off-by: Matti Kosola <matti.kosola@jolla.com>