### PR TITLE
Update manifest. MER#1824

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -10,12 +10,15 @@
 
   <project path="rpm" name="droid-src-syspart-f5121" remote="hybris"/>
 
+  <project path="bionic" name="android_bionic" remote="sony-patches"/>
+  <project path="device/sony/loire" name="device-sony-loire" remote="sony-patches"/>
   <project path="external/libnfc-nci" name="android_external_libnfc-nci" remote="sony-patches"/>
   <project path="external/toybox" name="android_external_toybox" remote="sony-patches"/>
   <project path="frameworks/av" name="android_frameworks_av" remote="sony-patches"/>
   <project path="frameworks/base" name="android_frameworks_base" remote="sony-patches"/>
   <project path="frameworks/opt/telephony" name="android_frameworks_opt_telephony" remote="sony-patches"/>
   <project path="hardware/broadcom/libbt" name="android_hardware_broadcom_libbt" remote="sony-patches"/>
+  <project path="hardware/libhardware" name="android_hardware_libhardware" remote="sony-patches"/>
   <project path="hardware/qcom/audio" name="android_hardware_qcom_audio" remote="sony-patches"/>
   <project path="hardware/qcom/display" name="android_hardware_qcom_display" remote="sony-patches"/>
   <project path="hardware/qcom/gps" name="android_hardware_qcom_gps" remote="sony-patches"/>
@@ -27,7 +30,6 @@
   <project path="device/sony/common" name="device-sony-common" remote="sony" revision="m-mr1"/>
   <project path="device/sony/common-headers" name="device-sony-common-headers" remote="sony" revision="aosp/LA.BR.1.3.3_rb2.14"/>
   <project path="device/sony/common-init" name="device-sony-common-init" remote="sony" revision="m-mr1"/>
-  <project path="device/sony/loire" name="device-sony-loire" remote="sony" revision="m-mr1"/>
   <project path="device/sony/sepolicy" name="device-sony-sepolicy" remote="sony" revision="m-mr1"/>
   <project path="device/sony/suzu" name="device-sony-suzu" remote="sony" revision="m-mr1"/>
   <project path="hardware/qcom/camera" name="camera" remote="sony" revision="aosp/LA.BR.1.3.3_rb2.14"/>
@@ -50,7 +52,6 @@
   <project name="device/sample"/>
   <project path="abi/cpp" name="platform/abi/cpp"/>
   <project path="art" name="platform/art"/>
-  <project path="bionic" name="platform/bionic"/>
   <project path="bootable/recovery" name="platform/bootable/recovery"/>
   <project path="build" name="platform/build">
     <copyfile dest="Makefile" src="core/root.mk"/>
@@ -193,7 +194,6 @@
   <project path="hardware/intel/img/psb_video" name="platform/hardware/intel/img/psb_video"/>
   <project path="hardware/intel/sensors" name="platform/hardware/intel/sensors"/>
   <project path="hardware/invensense" name="platform/hardware/invensense"/>
-  <project path="hardware/libhardware" name="platform/hardware/libhardware"/>
   <project path="hardware/libhardware_legacy" name="platform/hardware/libhardware_legacy"/>
   <project path="hardware/marvell/bt" name="platform/hardware/marvell/bt"/>
   <project path="hardware/mediatek" name="platform/hardware/mediatek"/>

--- a/tagged-manifest.xml
+++ b/tagged-manifest.xml
@@ -8,36 +8,37 @@
   
   <default remote="aosp" revision="refs/tags/android-6.0.1_r80" sync-j="4"/>
   
-  <project name="NXPNFCC_FW" path="vendor/nxp/NXPNFCC_FW" remote="NXP" revision="8b70766be6cdf8f84e9a397721002d2cfac92d41" upstream="master"/>
+  <project name="NXPNFCC_FW" path="vendor/nxp/NXPNFCC_FW" remote="NXP" revision="16fca3e60bf4e3890ddddeb7c119a42ef03a90d6" upstream="master"/>
+  <project name="android_bionic" path="bionic" remote="sony-patches" revision="3d110a45a3a363594d9d4ccd1bdae2c9a8f316d3" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_external_libnfc-nci" path="external/libnfc-nci" remote="sony-patches" revision="1f96f086d1b2c962f180734bd468d31014f298e8" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_external_toybox" path="external/toybox" remote="sony-patches" revision="678f2bbd26af4599e73150a8c598d189dfc121e1" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_frameworks_av" path="frameworks/av" remote="sony-patches" revision="5a3f4558b42deef0faf64dd99bf740e086be2053" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_frameworks_base" path="frameworks/base" remote="sony-patches" revision="de9587cbab4f17c7744e7ef721c54aad9680d0f6" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_frameworks_opt_telephony" path="frameworks/opt/telephony" remote="sony-patches" revision="9b8fa2a0bdf668cd1273bfde388b0e351c46b212" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_hardware_broadcom_libbt" path="hardware/broadcom/libbt" remote="sony-patches" revision="97490d1923dc459a7502c9f488d55a8c4577caf7" upstream="sony-aosp-6.0.1_r80-20170902"/>
-  <project name="android_hardware_qcom_audio" path="hardware/qcom/audio" remote="sony-patches" revision="24be7b102d897f02824d6a326adc7c52ae21b42e" upstream="sony-aosp-6.0.1_r80-20170902"/>
+  <project name="android_hardware_libhardware" path="hardware/libhardware" remote="sony-patches" revision="a5c33c20fe671eeed29ec449d167a6fe6aafa2ac" upstream="sony-aosp-6.0.1_r80-20170902"/>
+  <project name="android_hardware_qcom_audio" path="hardware/qcom/audio" remote="sony-patches" revision="55ca23ebe58d178d7784bf0e427d0df9bae43329" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_hardware_qcom_display" path="hardware/qcom/display" remote="sony-patches" revision="4101df8814dcffe665146d1f9611fb08fe7076f6" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_hardware_qcom_gps" path="hardware/qcom/gps" remote="sony-patches" revision="4d71e2437811266093c31cab4c4da7d081f68176" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_hardware_qcom_keymaster" path="hardware/qcom/keymaster" remote="sony-patches" revision="140e47c0deac29b4fe12408f450ba8200aa469bb" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_hardware_qcom_media" path="hardware/qcom/media" remote="sony-patches" revision="c35f8b426620c458c94048e55a884a9c0b91b1e4" upstream="sony-aosp-6.0.1_r80-20170902"/>
-  <project name="android_hardware_ril" path="hardware/ril" remote="sony-patches" revision="6522613603aa556b0794b2d1eacd5934f5110f01" upstream="sony-aosp-6.0.1_r80-20170902"/>
-  <project name="android_system_core" path="system/core" remote="sony-patches" revision="cdc3e7cde19bf76686859f358f4b18aa37a64c09" upstream="sony-aosp-6.0.1_r80-20170902"/>
+  <project name="android_hardware_ril" path="hardware/ril" remote="sony-patches" revision="4e15283fb76b9af5c286dda4cdd2e57e9e22ed6c" upstream="sony-aosp-6.0.1_r80-20170902"/>
+  <project name="android_system_core" path="system/core" remote="sony-patches" revision="d3b5b07209e4424a1df6fcee77350ad9f27ab0a8" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="camera" path="hardware/qcom/camera" remote="sony" revision="b66cda07a10d0ff2b043f6d391d62d938a1cf203" upstream="aosp/LA.BR.1.3.3_rb2.14"/>
-  <project name="device-sony-common" path="device/sony/common" remote="sony" revision="9df814cf4e415601465a5a20d9a40ae84ae0518d" upstream="m-mr1"/>
+  <project name="device-sony-common" path="device/sony/common" remote="sony" revision="66d13c6befcf6728a4aabb6f3c4c893863b017a0" upstream="m-mr1"/>
   <project name="device-sony-common-headers" path="device/sony/common-headers" remote="sony" revision="65c7a0cf63a4258f09d11cd856d39e1e3199a640" upstream="aosp/LA.BR.1.3.3_rb2.14"/>
   <project name="device-sony-common-init" path="device/sony/common-init" remote="sony" revision="6ec88d15e6b1d09fd38119ba668ce318adcf78d5" upstream="m-mr1"/>
-  <project name="device-sony-loire" path="device/sony/loire" remote="sony" revision="1d181a360ec3adb18c5c37ed6ce874a6fa57d49d" upstream="m-mr1"/>
+  <project name="device-sony-loire" path="device/sony/loire" remote="sony-patches" revision="2a2abf7de17aed3c06ed79ff20695f26106ab6df" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="device-sony-sepolicy" path="device/sony/sepolicy" remote="sony" revision="cbc0af26db3265f46642d02534928ae3388c9c40" upstream="m-mr1"/>
-  <project name="device-sony-suzu" path="device/sony/suzu" remote="sony" revision="b5efeeece389200899a13368f2e65510d343a446" upstream="m-mr1"/>
+  <project name="device-sony-suzu" path="device/sony/suzu" remote="sony" revision="7aa251793167303bda68dc5bfd8b142852fab4ec" upstream="m-mr1"/>
   <project name="device/common" revision="762617a12642c9de3e3ce66b26f6c8b122c06e0f" upstream="refs/tags/android-6.0.1_r80"/>
   <project name="device/generic/common" revision="11c092a6cbfcf6207f07a9a8e3398e747e7f5461" upstream="refs/tags/android-6.0.1_r80"/>
   <project name="device/sample" revision="b239828ba6f282793de417a46770c192c153ac47" upstream="refs/tags/android-6.0.1_r80"/>
-  <project name="droid-src-syspart-f5121" path="rpm" remote="hybris" revision="87fd9891c9fdec1040b155cd47514aa07946fcab" upstream="master"/>
+  <project name="droid-src-syspart-f5121" path="rpm" remote="hybris" revision="db22af3d2d85448c3c2d921e36f6c22b70809ed4" upstream="master"/>
   <project name="kernel" path="kernel/sony/msm" remote="sony" revision="90059be594ea30d1442ef1985e41c633c2bb8365" upstream="aosp/LA.BR.1.3.3_rb2.14"/>
-  <project name="macaddrsetup" path="vendor/sony-oss/macaddrsetup" remote="sony" revision="311408b6ff4cd10b43e5631ce8be627d603633bc" upstream="master"/>
+  <project name="macaddrsetup" path="vendor/sony-oss/macaddrsetup" remote="sony" revision="dceef471f223dbea9d87fdbec98c5e05d961758d" upstream="master"/>
   <project name="platform/abi/cpp" path="abi/cpp" revision="36b381298a4efb7c293d394d8b1acbda68230989" upstream="refs/tags/android-6.0.1_r80"/>
   <project name="platform/art" path="art" revision="1dff62f822392dd3f95ec23ba578bf42430ba112" upstream="refs/tags/android-6.0.1_r80"/>
-  <project name="platform/bionic" path="bionic" revision="06f6466e11bf4fe85337e0a734d526cedcdf7241" upstream="refs/tags/android-6.0.1_r80"/>
   <project name="platform/bootable/recovery" path="bootable/recovery" revision="99adefa7a36774115f18272e67a7ebe7d1b3fb9b" upstream="refs/tags/android-6.0.1_r80"/>
   <project name="platform/build" path="build" revision="85e023db6510bbeb1a01a0bb1f41a5a17af5d386" upstream="refs/tags/android-6.0.1_r80">
     <copyfile dest="Makefile" src="core/root.mk"/>
@@ -180,7 +181,6 @@
   <project name="platform/hardware/intel/img/psb_video" path="hardware/intel/img/psb_video" revision="cf82d4e3f5d063a5a284662052cbbc6f124f37e3" upstream="refs/tags/android-6.0.1_r80"/>
   <project name="platform/hardware/intel/sensors" path="hardware/intel/sensors" revision="6ef7662419981a762df75fbc57fcfde52902c123" upstream="refs/tags/android-6.0.1_r80"/>
   <project name="platform/hardware/invensense" path="hardware/invensense" revision="e0c1691f695f828608c36315fa405db2fa8d153e" upstream="refs/tags/android-6.0.1_r80"/>
-  <project name="platform/hardware/libhardware" path="hardware/libhardware" revision="58f48179cc250c770ee66a2d79651563b66e23de" upstream="refs/tags/android-6.0.1_r80"/>
   <project name="platform/hardware/libhardware_legacy" path="hardware/libhardware_legacy" revision="8af982d029f575a91158cbc870fdc94a70203134" upstream="refs/tags/android-6.0.1_r80"/>
   <project name="platform/hardware/marvell/bt" path="hardware/marvell/bt" revision="3f33d194e8300816b94d1d7b68b1d48c8f903251" upstream="refs/tags/android-6.0.1_r80"/>
   <project name="platform/hardware/mediatek" path="hardware/mediatek" revision="84eac90753d5c99bc0b05df34c400d1f58c01213" upstream="refs/tags/android-6.0.1_r80"/>
@@ -221,13 +221,13 @@
   <project name="platform/system/netd" path="system/netd" revision="c8683d7eb9bb95de2090431e8daaa45d92b45e38" upstream="refs/tags/android-6.0.1_r80"/>
   <project name="platform/system/security" path="system/security" revision="1f76969bd8b6179f256dafb938bb458bc997c23d" upstream="refs/tags/android-6.0.1_r80"/>
   <project name="platform/system/vold" path="system/vold" revision="2403b4d0561c756ed5102aaf6048a80c9993f6f8" upstream="refs/tags/android-6.0.1_r80"/>
-  <project name="thermanager" path="vendor/sony-oss/thermanager" remote="sony" revision="60e15f0dc4828bafbb83d027eaefb067878a7615" upstream="master"/>
-  <project name="timekeep" path="vendor/sony-oss/timekeep" remote="sony" revision="1d0130eb83da510c56ad53955977c4ea6060589d" upstream="master"/>
-  <project name="vendor-broadcom-bt-fm" path="vendor/broadcom/bt-fm" remote="sony" revision="cbf8b3e4935be3be1343c9f690b7bc7385bde773" upstream="master"/>
+  <project name="thermanager" path="vendor/sony-oss/thermanager" remote="sony" revision="383805fcec4634288085b7b9f0729e2a968ae7f9" upstream="master"/>
+  <project name="timekeep" path="vendor/sony-oss/timekeep" remote="sony" revision="193d39a2411eb336717595b580a45a50f9a6d62d" upstream="master"/>
+  <project name="vendor-broadcom-bt-fm" path="vendor/broadcom/bt-fm" remote="sony" revision="2da2991694277c0e29782fbadffe69027adeb09a" upstream="master"/>
   <project name="vendor-broadcom-wlan" path="vendor/broadcom/wlan" remote="sony" revision="c91fb00eb661055f0837f4a1b64c26dec0bae43b" upstream="master"/>
-  <project name="vendor-nxp" path="vendor/nxp/" remote="sony" revision="c65ad592e4b0a2994f27dbbde32825aed2a1cd6b" upstream="master"/>
-  <project name="vendor-qcom-opensource-dataservices" path="vendor/qcom/opensource/dataservices" remote="sony" revision="ec30914d05895b0b328d95ad4db4a6f863d98626" upstream="master"/>
+  <project name="vendor-nxp" path="vendor/nxp/" remote="sony" revision="d050ec12ef6e622c2a1b268c9ff90ccbe14dec7e" upstream="master"/>
+  <project name="vendor-qcom-opensource-dataservices" path="vendor/qcom/opensource/dataservices" remote="sony" revision="11000ae202fe824c732efde149cf90becec015c0" upstream="master"/>
   <project name="vendor-qcom-opensource-fm" path="vendor/qcom/opensource/fm" remote="sony" revision="aabbad189c592aa67facec37bb4d52eb5f991738" upstream="master"/>
-  <project name="vendor-qcom-opensource-location" path="vendor/qcom/opensource/location" remote="sony" revision="246ff9468011e209ef1ccad8d9ffc072c04042e1" upstream="m-mr1"/>
-  <project name="vendor-sony-oss-fingerprint" path="vendor/sony-oss/fingerprint" remote="sony" revision="2eb911f450bb470acacc206c96b247d19e453050" upstream="master"/>
+  <project name="vendor-qcom-opensource-location" path="vendor/qcom/opensource/location" remote="sony" revision="4901f9495363d5bb9bce784a932cdcf3ee1fbd3e" upstream="m-mr1"/>
+  <project name="vendor-sony-oss-fingerprint" path="vendor/sony-oss/fingerprint" remote="sony" revision="59bb4e148d0563f4f971b849dd39e28655cc45d5" upstream="master"/>
 </manifest>


### PR DESCRIPTION
[bionic] linker: handle files under /odm. MER#1824
[bionic] Necessary symbols to make Android 7 vendor binaries compatible
[hardware_qcom_audio] Better handling of primary output. JB#39478
[hardware_libhardware] Reference files also under /odm. MER#1824
[hardware_ril] Necessary protocol backports to make Android 7 vendor binaries compatible
[system_core] Better support transition to Android 7 BSP
[device_sony] Transition from /system/vendor to /odm. MER#1824
[device_sony] Build doesn't require vendor SW binaries anymore
[rpm] Build doesn't require vendor SW binaries anymore