### PR TITLE
Update manifest

### DIFF
--- a/tagged-manifest.xml
+++ b/tagged-manifest.xml
@@ -27,7 +27,7 @@
   <project name="android_hardware_qcom_keymaster" path="hardware/qcom/keymaster" remote="sony-patches" revision="140e47c0deac29b4fe12408f450ba8200aa469bb" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_hardware_qcom_media" path="hardware/qcom/media" remote="sony-patches" revision="c35f8b426620c458c94048e55a884a9c0b91b1e4" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_hardware_ril" path="hardware/ril" remote="sony-patches" revision="4e15283fb76b9af5c286dda4cdd2e57e9e22ed6c" upstream="sony-aosp-6.0.1_r80-20170902"/>
-  <project name="android_kernel_sony_msm" path="kernel/sony/msm" remote="hybris-patches" revision="b178f3e1a8a82dce3edb87703f2d7789317354f0" upstream="hybris-sony-aosp-6.0.1_r80-20170902"/>
+  <project name="android_kernel_sony_msm" path="kernel/sony/msm" remote="hybris-patches" revision="e040e7710f6806e3ff4c4351a3ac6fc6ae0d044c" upstream="hybris-sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_system_core" path="system/core" remote="hybris-patches" revision="58c3df67d8dc0b5783f8db473c0caeea0b0d1204" upstream="hybris-sony-aosp-6.0.1_r80-20170902"/>
   <project name="camera" path="hardware/qcom/camera" remote="sony" revision="b66cda07a10d0ff2b043f6d391d62d938a1cf203" upstream="aosp/LA.BR.1.3.3_rb2.14"/>
   <project name="device-sony-common" path="device/sony/common" remote="hybris-patches" revision="c1a6aea7efdef6876c906b6dcab399283f744582" upstream="hybris-sony-aosp-6.0.1_r80-20170902"/>
@@ -41,7 +41,7 @@
   <project name="droid-hal-f5121" path="rpm" remote="hybris" revision="0cc3293e74c71ce0222be6f5896943818788adcb" upstream="master"/>
   <project name="hybris-boot" path="hybris/hybris-boot" remote="hybris" revision="837e5f9ac6025edc838c9dfc235b251872202b0a" upstream="master"/>
   <project name="macaddrsetup" path="vendor/sony-oss/macaddrsetup" remote="sony" revision="dceef471f223dbea9d87fdbec98c5e05d961758d" upstream="master"/>
-  <project name="mer-kernel-check" path="hybris/mer-kernel-check" remote="hybris" revision="5d7354ce49d4909171a4b4c301b36b63fea71cfd" upstream="master"/>
+  <project name="mer-kernel-check" path="hybris/mer-kernel-check" remote="hybris" revision="39b5ad47853e7cafe11c81c0ba4d71ba550f31c3" upstream="master"/>
   <project name="platform/abi/cpp" path="abi/cpp" revision="36b381298a4efb7c293d394d8b1acbda68230989" upstream="refs/tags/android-6.0.1_r80"/>
   <project name="platform/bootable/recovery" path="bootable/recovery" revision="99adefa7a36774115f18272e67a7ebe7d1b3fb9b" upstream="refs/tags/android-6.0.1_r80"/>
   <project name="platform/external/bison" path="external/bison" revision="c2418b886165add7f5a31fc5609f0ce2d004a90e" upstream="refs/tags/android-6.0.1_r80"/>


### PR DESCRIPTION
[mer-kernel-check] Make Android low memory killer optional. JB#40302
[kernel_sony_msm] Enable low memory killer. Fixes JB#40302
[kernel_sony_msm] Add memnotify driver. JB#40302
[kernel_sony_msm] Disable sw interrupts in nr_blockdev_pages(). JB#40302
[kernel_sony_msm] Enable memnotify. JB#40302