### PR TITLE
Update manifest

### DIFF
--- a/tagged-manifest.xml
+++ b/tagged-manifest.xml
@@ -27,7 +27,7 @@
   <project name="android_hardware_qcom_keymaster" path="hardware/qcom/keymaster" remote="sony-patches" revision="140e47c0deac29b4fe12408f450ba8200aa469bb" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_hardware_qcom_media" path="hardware/qcom/media" remote="sony-patches" revision="c35f8b426620c458c94048e55a884a9c0b91b1e4" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_hardware_ril" path="hardware/ril" remote="sony-patches" revision="4e15283fb76b9af5c286dda4cdd2e57e9e22ed6c" upstream="sony-aosp-6.0.1_r80-20170902"/>
-  <project name="android_kernel_sony_msm" path="kernel/sony/msm" remote="hybris-patches" revision="e040e7710f6806e3ff4c4351a3ac6fc6ae0d044c" upstream="hybris-sony-aosp-6.0.1_r80-20170902"/>
+  <project name="android_kernel_sony_msm" path="kernel/sony/msm" remote="hybris-patches" revision="13fedfc62120959f2348f68659770a270c89c27f" upstream="hybris-sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_system_core" path="system/core" remote="hybris-patches" revision="58c3df67d8dc0b5783f8db473c0caeea0b0d1204" upstream="hybris-sony-aosp-6.0.1_r80-20170902"/>
   <project name="camera" path="hardware/qcom/camera" remote="sony" revision="b66cda07a10d0ff2b043f6d391d62d938a1cf203" upstream="aosp/LA.BR.1.3.3_rb2.14"/>
   <project name="device-sony-common" path="device/sony/common" remote="hybris-patches" revision="c1a6aea7efdef6876c906b6dcab399283f744582" upstream="hybris-sony-aosp-6.0.1_r80-20170902"/>


### PR DESCRIPTION
[kernel_sony_msm] ext4: evict inline data when writing to memory map.

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>