### PR TITLE
[sony-nile] Update manifest. JB#42770, MER#1948, MER#1947

### DIFF
--- a/tagged-manifest.xml
+++ b/tagged-manifest.xml
@@ -9,8 +9,9 @@
   
   <default remote="aosp" revision="refs/tags/android-8.1.0_r35" sync-j="4"/>
   
-  <project name="NXPNFCC_FW" path="vendor/nxp/NXPNFCC_FW" remote="NXP" revision="9901c58d5e24801d86d72ab406f007326078f478" upstream="master"/>
+  <project name="NXPNFCC_FW" path="vendor/nxp/NXPNFCC_FW" remote="NXP" revision="5ce2ae047abc44c1547d6ceebaa22c58ae1bd477" upstream="master"/>
   <project name="android_bionic" path="bionic" remote="hybris-patches" revision="8bd8f3cafb1bd147f167d87f885ee93a6b58bb01" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
+  <project name="android_bootable_recovery" path="bootable/recovery" remote="hybris-patches" revision="3c6a8d9187b92257bb28939bf9474865f30846f7" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
   <project name="android_build" path="build/make" remote="hybris-patches" revision="bf146f8e9bb8de0a0592e7b850a58ae04498ea5b" upstream="hybris-sony-aosp-8.1.0_r35_20180714">
     <copyfile dest="Makefile" src="core/root.mk"/>
     <linkfile dest="build/CleanSpec.mk" src="CleanSpec.mk"/>
@@ -25,30 +26,36 @@
   <project name="android_frameworks_av" path="frameworks/av" remote="hybris-patches" revision="f2333dd2bdba5c0059f2bce4c1bc1066deaa539a" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
   <project name="android_frameworks_native" path="frameworks/native" remote="hybris-patches" revision="2ecf69b220d3a2fa307cb5fbef345b8fb8d0196a" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
   <project name="android_hardware_libhardware" path="hardware/libhardware" remote="hybris-patches" revision="d798db4236e0baa4111ab2633236a3a7eefc66c5" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
-  <project name="android_kernel_sony_msm" path="kernel/sony/msm-4.4/kernel" remote="hybris-patches" revision="a482a4291f14e89a4828445062683112e7f2db87" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
-  <project name="android_system_core" path="system/core" remote="hybris-patches" revision="cb5edcdf96d342a6a12bcfd5c69547826b68b3b0" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
-  <project name="camera" path="vendor/qcom/opensource/camera" remote="sony" revision="c8dcff8aeed81b6accf7cef67fc9766168614878" upstream="aosp/LA.UM.6.4.r1"/>
-  <project name="device-sony-akari" path="device/sony/akari" remote="sony" revision="17f474ca50c68b0de762a165b1dc0a2bf06e08dd" upstream="master"/>
-  <project name="device-sony-apollo" path="device/sony/apollo" remote="sony" revision="07ee5f701bcf277d28d87b476b59dada470d465c" upstream="master"/>
-  <project name="device-sony-blanc" path="device/sony/blanc" remote="sony" revision="0109896e68d197c34e6bf64a156c1288d9cfdadc" upstream="master"/>
-  <project name="device-sony-common" path="device/sony/common" remote="sony" revision="23b87e74e417230f6c89138370b3fc430306aaa9" upstream="master"/>
+  <project name="android_hardware_qcom_audio" path="hardware/qcom/audio" remote="hybris-patches" revision="0465b4d34b2fd675a2f411c5a57d38b141bd0212" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
+  <project name="android_hardware_qcom_bt" path="hardware/qcom/bt" remote="hybris-patches" revision="90b1ad44312537de1029c87c7df011af1376f523" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
+  <project name="android_hardware_qcom_display" path="hardware/qcom/display" remote="hybris-patches" revision="d3779468c4821b0914c5d67088577b5874a3633e" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
+  <project name="android_hardware_qcom_gps" path="hardware/qcom/gps" remote="hybris-patches" revision="663dbe453987314ac5831efd07897b3e929d8023" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
+  <project name="android_hardware_qcom_media" path="hardware/qcom/media" remote="hybris-patches" revision="e01e032feb6df056104beda1cf682afb5ef98a2f" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
+  <project name="android_kernel_sony_msm" path="kernel/sony/msm-4.4/kernel" remote="hybris-patches" revision="bf390d946d07107ba0a62f00ba3270dd3e93af92" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
+  <project name="android_system_core" path="system/core" remote="hybris-patches" revision="70b3da2e1f9865a1196c102da8cddf5eb9d39500" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
+  <project name="android_system_nfc" path="system/nfc" remote="hybris-patches" revision="0e036edb77546f74a2c7eea9c5506415cb1dde2e" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
+  <project name="camera" path="vendor/qcom/opensource/camera" remote="sony" revision="dc9af5d36009caa60b9b01a256a7f8ce4c1897f1" upstream="aosp/LA.UM.6.4.r1"/>
+  <project name="device-sony-akari" path="device/sony/akari" remote="sony" revision="160df5bbfa289453c519f8c7b8f27bfee82c767f" upstream="o-mr1"/>
+  <project name="device-sony-apollo" path="device/sony/apollo" remote="sony" revision="c3f670d59069ed7d7b0bc2d1ea04550dccd8e05e" upstream="o-mr1"/>
+  <project name="device-sony-blanc" path="device/sony/blanc" remote="sony" revision="0109896e68d197c34e6bf64a156c1288d9cfdadc" upstream="o-mr1"/>
+  <project name="device-sony-common" path="device/sony/common" remote="sony" revision="9cb4f4e994ca5b8739624431afac8497757fc30f" upstream="o-mr1"/>
   <project name="device-sony-common-headers" path="kernel/sony/msm-4.4/common-headers" remote="sony" revision="c7e52e0c6cedf83c15d938688365d0a6b6bbd3fe" upstream="aosp/LA.UM.6.4.r1"/>
-  <project name="device-sony-discovery" path="device/sony/discovery" remote="sony" revision="e8da7c77f51f3a4fc3cf140a5679887735b7e8dd" upstream="master"/>
-  <project name="device-sony-dora" path="device/sony/dora" remote="sony" revision="2f044dc0f0ab2ad62d0b9b1ca55881b12abaf5ff" upstream="master"/>
-  <project name="device-sony-kagura" path="device/sony/kagura" remote="sony" revision="167302b70720b3d44e6c53c4e09f1045a692d22a" upstream="master"/>
-  <project name="device-sony-keyaki" path="device/sony/keyaki" remote="sony" revision="e4de29f40d1d65d5a83805bf538a5ccd0924b7a7" upstream="master"/>
-  <project name="device-sony-kugo" path="device/sony/kugo" remote="sony" revision="e75a1e0638d299814bfe12986a21105dc7cdf56d" upstream="master"/>
-  <project name="device-sony-lilac" path="device/sony/lilac" remote="sony" revision="93f5cac07ecc294d14366828bf15e28e3db3126c" upstream="master"/>
-  <project name="device-sony-loire" path="device/sony/loire" remote="sony" revision="9a5103a8f9f69f9e4b5f7d0ab84bbbeb84fd414f" upstream="master"/>
-  <project name="device-sony-maple" path="device/sony/maple" remote="sony" revision="c534bb7628fd4f3dd3660f88118ba66726c8e316" upstream="master"/>
-  <project name="device-sony-nile" path="device/sony/nile" remote="hybris-patches" revision="883a5f2bee6e72b0aec89fde0c74feb2849efd3b" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
-  <project name="device-sony-pioneer" path="device/sony/pioneer" remote="sony" revision="dbe717e9016574f001d96fa9936291f3d8b33806" upstream="master"/>
-  <project name="device-sony-poplar" path="device/sony/poplar" remote="sony" revision="186ed5d4989739bd73fbd06d6705f6e33c8f5766" upstream="master"/>
-  <project name="device-sony-sepolicy" path="device/sony/sepolicy" remote="sony" revision="2b92afbd0a3296de7b76976baeb4a326c0f225dd" upstream="master"/>
-  <project name="device-sony-suzu" path="device/sony/suzu" remote="sony" revision="3dd0e08f415a5b2e898913f2c333edfd939ff7f4" upstream="master"/>
-  <project name="device-sony-tama" path="device/sony/tama" remote="sony" revision="3490314e89321ff544c0a182544c34960e1aa539" upstream="master"/>
-  <project name="device-sony-tone" path="device/sony/tone" remote="sony" revision="2b5f447b12f47602d275d1166ba7e4bf0d3e11db" upstream="master"/>
-  <project name="device-sony-yoshino" path="device/sony/yoshino" remote="sony" revision="9a0bdb8b790a1bf26edf434fd30451dbb26bea76" upstream="master"/>
+  <project name="device-sony-discovery" path="device/sony/discovery" remote="sony" revision="ad6cadc3ab865651a28fb4a67d726c2287697966" upstream="o-mr1"/>
+  <project name="device-sony-dora" path="device/sony/dora" remote="sony" revision="b0b27e3effe6a107560327cf38bf654b61eeedee" upstream="o-mr1"/>
+  <project name="device-sony-kagura" path="device/sony/kagura" remote="sony" revision="4d36d6c043f4c4817e949d56331975a96f335ab9" upstream="o-mr1"/>
+  <project name="device-sony-keyaki" path="device/sony/keyaki" remote="sony" revision="00dcbdd8f0b8a13e6a83b27f64ff403b72839b95" upstream="o-mr1"/>
+  <project name="device-sony-kugo" path="device/sony/kugo" remote="sony" revision="e75a1e0638d299814bfe12986a21105dc7cdf56d" upstream="o-mr1"/>
+  <project name="device-sony-lilac" path="device/sony/lilac" remote="sony" revision="93f5cac07ecc294d14366828bf15e28e3db3126c" upstream="o-mr1"/>
+  <project name="device-sony-loire" path="device/sony/loire" remote="sony" revision="ae59be76a7202b5c322ab06e04b81a1c5369786a" upstream="o-mr1"/>
+  <project name="device-sony-maple" path="device/sony/maple" remote="sony" revision="b5356bc08b9846e45985c9405e36bd0f81909adf" upstream="o-mr1"/>
+  <project name="device-sony-nile" path="device/sony/nile" remote="hybris-patches" revision="df760b3c7ed0fea60a62926fea8b93a7aa748964" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
+  <project name="device-sony-pioneer" path="device/sony/pioneer" remote="sony" revision="cffabc89f4988eaeb32dfb79566a949e861203e1" upstream="o-mr1"/>
+  <project name="device-sony-poplar" path="device/sony/poplar" remote="sony" revision="2e694b40dab5b9daca5bd237a6e9535d7b5b945d" upstream="o-mr1"/>
+  <project name="device-sony-sepolicy" path="device/sony/sepolicy" remote="sony" revision="38a32428446ff52965c21d58c99d03b2493eb0bc" upstream="o-mr1"/>
+  <project name="device-sony-suzu" path="device/sony/suzu" remote="sony" revision="2b71488da806a113d97694ade10e0a71b4db4337" upstream="o-mr1"/>
+  <project name="device-sony-tama" path="device/sony/tama" remote="sony" revision="c2d8741eb595fd31e2a0b05e9da76c4bb4f202aa" upstream="o-mr1"/>
+  <project name="device-sony-tone" path="device/sony/tone" remote="sony" revision="d2f623158c7d1896c3464d9d3e2c84eab40c8514" upstream="o-mr1"/>
+  <project name="device-sony-yoshino" path="device/sony/yoshino" remote="sony" revision="6eae7bc81e6767bf7cddedfb456fd17c693d408a" upstream="o-mr1"/>
   <project name="device/common" revision="f87323bed1150074fee5a0ad64d76aaed0c58f00" upstream="refs/tags/android-8.1.0_r35"/>
   <project name="device/google/atv" revision="0956280428ba979a2a78e852dd484167ece3b9af" upstream="refs/tags/android-8.1.0_r35"/>
   <project name="device/google/contexthub" revision="6c6efc263a0daa6d6a377ea8e129d8bbc7b32675" upstream="refs/tags/android-8.1.0_r35"/>
@@ -59,18 +66,17 @@
   <project clone-depth="1" name="device/google/vrservices" revision="b290ba549b38447937773e3698e4678015550684" upstream="refs/tags/android-8.1.0_r35"/>
   <project name="device/google/wahoo" revision="e9e17ed4e99b168e8ce7a999b22bde4ffb32fcc7" upstream="refs/tags/android-8.1.0_r35"/>
   <project name="device/sample" revision="509608c76570d623c05952c8eecdc2868ca8a952" upstream="refs/tags/android-8.1.0_r35"/>
-  <project name="droid-hal-sony-nile" path="rpm" remote="hybris" revision="42a4e5ea1d8e84f6b40c32a1eddfc5260f0809ef" upstream="master"/>
-  <project name="hardware-qcom-bootctrl" path="hardware/qcom/bootctrl" remote="sony" revision="f441cdfc41b5055ee53ee016135cb9b6022c7cd4" upstream="master"/>
+  <project name="droid-hal-sony-nile" path="rpm" remote="hybris" revision="5fa7d7e4d7adc22a77867be7c600cc87eeb4ec4b" upstream="master"/>
+  <project name="hardware-qcom-display" path="hardware/qcom/display/sde" remote="sony" revision="e63f75021d59ad0e922f5fafe740ab9e7eff707b" upstream="aosp/LA.UM.6.3.r1"/>
   <project name="hardware-qcom-wlan" path="vendor/qcom/opensource/wlan" remote="sony" revision="d8a7fe7303cdc5f1087a186cd95388c979fc4dad" upstream="master"/>
-  <project name="hybris-boot" path="hybris/hybris-boot" remote="hybris" revision="04dfe1e81b434afd2597aab2aac967f69bd5aea7" upstream="master"/>
+  <project name="hybris-boot" path="hybris/hybris-boot" remote="hybris" revision="bd4134fec42b66c9e33ec287a59b7dabe5ae33b2" upstream="master"/>
   <project name="kernel/tests" revision="fa4729e5d6aeba19cc9ea0b3cbd4eb085865beda" upstream="refs/tags/android-8.1.0_r35"/>
   <project name="libhybris-1" path="external/libhybris" remote="krnlyng" revision="067914df53f7261ef0a884f9a505f598805a7ec8" upstream="android8-initial"/>
   <project name="macaddrsetup" path="vendor/oss/macaddrsetup" remote="sony" revision="bd7ce4eb762bb76cfddb4d4268352f8d3a71edd9" upstream="master"/>
   <project name="mer-kernel-check" path="hybris/mer-kernel-check" remote="hybris" revision="39b5ad47853e7cafe11c81c0ba4d71ba550f31c3" upstream="master"/>
   <project name="packages-apps-FMRadio" path="packages/apps/FMRadio" remote="sony" revision="680e46c71260e0bbd9517b82a9b7be7902745698" upstream="master"/>
-  <project name="packages_apps_ExtendedSettings" path="packages/apps/ExtendedSettings" remote="sony" revision="35119720fcb561ad121b69f6adb52d312b937d4e" upstream="master"/>
+  <project name="packages_apps_ExtendedSettings" path="packages/apps/ExtendedSettings" remote="sony" revision="bce1ff54637ab17b5b2bd4b1eb37016b00613a82" upstream="master"/>
   <project name="platform/art" path="art" revision="7f13ce4d95e2f8e38a82021058025509b7e994df" upstream="refs/tags/android-8.1.0_r35"/>
-  <project name="android_bootable_recovery" remote="hybris-patches" path="bootable/recovery" revision="3c6a8d9187b92257bb28939bf9474865f30846f7" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
   <project name="platform/build/blueprint" path="build/blueprint" revision="a011038d864e3faa528ec1037a568e5824955a0f" upstream="refs/tags/android-8.1.0_r35"/>
   <project name="platform/build/kati" path="build/kati" revision="51f78826f5d431981903ef82c51bdb868438717d" upstream="refs/tags/android-8.1.0_r35"/>
   <project name="platform/build/soong" path="build/soong" revision="3d83ebe1768d676c90e8fa3d508157f4654821e5" upstream="refs/tags/android-8.1.0_r35">
@@ -398,13 +404,9 @@
   <project name="platform/hardware/interfaces" path="hardware/interfaces" revision="5fe01443e69365f7c6017f08d8ec0509417a680e" upstream="refs/tags/android-8.1.0_r35"/>
   <project name="platform/hardware/invensense" path="hardware/invensense" revision="11e5ff75af866f91622b6008fa13db1c3685ae69" upstream="refs/tags/android-8.1.0_r35"/>
   <project name="platform/hardware/libhardware_legacy" path="hardware/libhardware_legacy" revision="7e46cfffd8c8db9547b4717b8408dd9b0cb83f29" upstream="refs/tags/android-8.1.0_r35"/>
-  <project name="android_hardware_qcom_audio" remote="hybris-patches" path="hardware/qcom/audio" revision="0465b4d34b2fd675a2f411c5a57d38b141bd0212" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
-  <project name="android_hardware_qcom_bt" remote="hybris-patches" path="hardware/qcom/bt" revision="ff390f39c6cc6e4c54c0257ed63a2e340454ddc1" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
+  <project name="platform/hardware/qcom/bootctrl" path="hardware/qcom/bootctrl" revision="2f294e58e7ed7d788d35569022f59cc9fd0d3e30" upstream="refs/tags/android-8.1.0_r35"/>
   <project name="platform/hardware/qcom/data/ipacfg-mgr" path="hardware/qcom/data/ipacfg-mgr" revision="da0af80f9a1eba30270e58efeac9481c4dabdc46" upstream="refs/tags/android-8.1.0_r35"/>
-  <project name="android_hardware_qcom_display" remote="hybris-patches" path="hardware/qcom/display" revision="d3779468c4821b0914c5d67088577b5874a3633e" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
-  <project name="android_hardware_qcom_gps" path="hardware/qcom/gps" revision="663dbe453987314ac5831efd07897b3e929d8023" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
   <project name="platform/hardware/qcom/keymaster" path="hardware/qcom/keymaster" revision="b9d7a35c05cac901a65d09849f90f1b4146d10e8" upstream="refs/tags/android-8.1.0_r35"/>
-  <project name="android_hardware_qcom_media" remote="hybris-patches" path="hardware/qcom/media" revision="e01e032feb6df056104beda1cf682afb5ef98a2f" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
   <project name="platform/hardware/qcom/msm8998" path="hardware/qcom/msm8998" revision="4d554ba927d41caac6128d731b66e6d593b27514" upstream="refs/tags/android-8.1.0_r35"/>
   <project name="platform/hardware/qcom/power" path="hardware/qcom/power" revision="3a098ee1f89c398b9d6e7b5dfae9c694994f8bc4" upstream="refs/tags/android-8.1.0_r35"/>
   <project name="platform/hardware/qcom/wlan" path="hardware/qcom/wlan" revision="8b94981ce47caac688d27fe222c3ce18b046e1ab" upstream="refs/tags/android-8.1.0_r35"/>
@@ -557,7 +559,6 @@
   <project name="platform/system/libvintf" path="system/libvintf" revision="9db9b147602210e6ae4b40848c49a7bfeeaefcff" upstream="refs/tags/android-8.1.0_r35"/>
   <project name="platform/system/media" path="system/media" revision="75e3545d978315d1988221181c7506c06b33a8ae" upstream="refs/tags/android-8.1.0_r35"/>
   <project name="platform/system/netd" path="system/netd" revision="cb160d358263b4cd5aca3d54521355a6737828a2" upstream="refs/tags/android-8.1.0_r35"/>
-  <project name="android_system_nfc" remote="hybris-patches" path="system/nfc" revision="0e036edb77546f74a2c7eea9c5506415cb1dde2e" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
   <project name="platform/system/nvram" path="system/nvram" revision="a2cbda182e4631dc45b3e988db9a6c0a0c36a610" upstream="refs/tags/android-8.1.0_r35"/>
   <project name="platform/system/security" path="system/security" revision="8b84e6d77fbd69a71fb051f21eb64b597927cbb1" upstream="refs/tags/android-8.1.0_r35"/>
   <project name="platform/system/sepolicy" path="system/sepolicy" revision="bd143923ddea313bee84042e8320b5fa8eb4051e" upstream="refs/tags/android-8.1.0_r35"/>
@@ -586,25 +587,28 @@
   <project name="platform/tools/tradefederation" path="tools/tradefederation/core" revision="86d42d1f8ee02c3402d116a22898ac7944b48db9" upstream="refs/tags/android-8.1.0_r35"/>
   <project name="platform/tools/tradefederation/contrib" path="tools/tradefederation/contrib" revision="8dd3029197cdaa6d9e867d4c645b489a6f9f52b6" upstream="refs/tags/android-8.1.0_r35"/>
   <project name="release-keys" path="vendor/oss/release-keys" remote="sony" revision="3fc0cf01697b7ac667ca75047bb81af6ccc8d29d" upstream="master"/>
-  <project name="repo_update" path="vendor/oss/repo_update" remote="sony" revision="302668be3e9f818737bed7fd9d27bead9218f25d" upstream="android-8.1.0_r3">
+  <project name="repo_update" path="vendor/oss/repo_update" remote="sony" revision="1ebec026499cf8a23b8487de8254cd8368aeafac" upstream="android-8.1.0_r3">
     <linkfile dest="repo_update.sh" src="repo_update.sh"/>
   </project>
   <project name="thermanager" path="vendor/oss/thermanager" remote="sony" revision="87297db29b81ae9dedb386f75db8457e871a5a59" upstream="master"/>
-  <project name="timekeep" path="vendor/oss/timekeep" remote="sony" revision="42ec86af6a5114539bfaf03805975709d9cb727a" upstream="master"/>
+  <project name="timekeep" path="vendor/oss/timekeep" remote="sony" revision="3ed2c245a67d09879cb209c12fc18c2a7f33e63b" upstream="master"/>
   <project name="toolchain/binutils" revision="a4125cf8aeab9dfeac00f1bda80645987897152f" upstream="refs/tags/android-8.1.0_r35"/>
-  <project name="transpower" path="vendor/oss/transpower" remote="sony" revision="b237a0e6a9e32057b18584b6f92cb851d5003616" upstream="master"/>
+  <project name="transpower" path="vendor/oss/transpower" remote="sony" revision="7d1dd74c64a7bc2c8d3d01097450c007973fdcec" upstream="master"/>
   <project name="vendor-broadcom-bt-fm" path="vendor/broadcom/bt-fm" remote="sony" revision="2da2991694277c0e29782fbadffe69027adeb09a" upstream="master"/>
   <project name="vendor-broadcom-wlan" path="vendor/broadcom/wlan" remote="sony" revision="3804258b2d466f907f886e34787e6b8cdcf7236a" upstream="master"/>
   <project name="vendor-nxp" path="vendor/nxp/" remote="sony" revision="08cfed8a9711116edd96ffc91b0d85f0af737cbb" upstream="master"/>
   <project name="vendor-qcom-opensource-dataservices" path="vendor/qcom/opensource/dataservices" remote="sony" revision="ee5fafdae0a9daecb2b801466fcb65969e4219fb" upstream="master"/>
   <project name="vendor-qcom-opensource-fm" path="vendor/qcom/opensource/fm" remote="sony" revision="aabbad189c592aa67facec37bb4d52eb5f991738" upstream="master"/>
-  <project name="vendor-qcom-opensource-location" path="vendor/qcom/opensource/location" remote="sony" revision="034610b867dc47366e0696c315debc47d52c1dfb" upstream="o-mr1"/>
+  <project name="vendor-qcom-opensource-interfaces" path="vendor/qcom/opensource/interfaces" remote="sony" revision="ed3af2f12b3ed388029e471791313a8264bc8d6a" upstream="aosp/LA.UM.6.3.r1">
+    <copyfile dest="vendor/qcom/opensource/Android.bp" src="os_pickup.bp"/>
+  </project>
+  <project name="vendor-qcom-opensource-location" path="vendor/qcom/opensource/location" remote="sony" revision="a21df4aafba44266d5f99d1566b3dcfd987bd5cc" upstream="o-mr1"/>
   <project name="vendor-qcom-opensource-wlan-fw-api" path="kernel/sony/msm-4.4/kernel/drivers/staging/wlan-qc/fw-api" remote="sony" revision="da68c7f2f560703880d2204c9b050849dfed6aa3" upstream="aosp/LA.UM.6.4.r1"/>
   <project name="vendor-qcom-opensource-wlan-qca-wifi-host-cmn" path="kernel/sony/msm-4.4/kernel/drivers/staging/wlan-qc/qca-wifi-host-cmn" remote="sony" revision="3f0e701ec2fd40984c66ddc6b4bb52d6c8a20fc1" upstream="aosp/LA.UM.6.4.r1"/>
-  <project name="vendor-qcom-opensource-wlan-qcacld-3.0" path="kernel/sony/msm-4.4/kernel/drivers/staging/wlan-qc/qcacld-3.0" remote="sony" revision="e339e178b401041da40fe4f69fefeebc3b3ce0ce" upstream="aosp/LA.UM.6.4.r1"/>
-  <project name="vendor-sony-oss-cash" path="vendor/oss/cash" remote="sony" revision="9a40635a4a0b670affbc094feef344c23b7bd240" upstream="master"/>
-  <project name="vendor-sony-oss-fingerprint" path="vendor/oss/fingerprint" remote="sony" revision="24921115c43814037b663066ed6d47a4b8f56b2a" upstream="master"/>
-  <project name="vendor-sony-oss-projection" path="vendor/oss/projection" remote="sony" revision="84f3eb01b9338108d4dbfb3f64c251c54a6427a1" upstream="master"/>
+  <project name="vendor-qcom-opensource-wlan-qcacld-3.0" path="kernel/sony/msm-4.4/kernel/drivers/staging/wlan-qc/qcacld-3.0" remote="sony" revision="ce1d5f37accf1fa896c9f3b52e89cb643a1e0d98" upstream="aosp/LA.UM.6.4.r1"/>
+  <project name="vendor-sony-oss-cash" path="vendor/oss/cash" remote="sony" revision="05e140369baf3ef98a837ea50b8e44be645b4b90" upstream="master"/>
+  <project name="vendor-sony-oss-fingerprint" path="vendor/oss/fingerprint" remote="sony" revision="40e706159b2715dd281f53dc578d978d747145b3" upstream="master"/>
+  <project name="vendor-sony-oss-projection" path="vendor/oss/projection" remote="sony" revision="1123d5b827fda74df7032282156af183370b0069" upstream="master"/>
   
   <repo-hooks enabled-list="pre-upload" in-project="platform/tools/repohooks"/>
 </manifest>


### PR DESCRIPTION
[rpm] after dsp folder fix we can fix this path. JB#42774
[kernel] Merge upstream changes. JB#42213
[system/core] (hybris) ignore "mount" and "mkdir /tmp" commands entirely. JB#42770
[device/sony/common] Do not create the dsp directory since it is created by all platforms which need it, as a symlink. JB#42774
[device/sony/nile] (hybris) Remove duplicate vendor mountpoint and add back odm mountpoint. MER#1948
[hybris/hybris-boot] Adapt pioneer mountpoints to upstream changes. MER#1948
[hybris/hybris-boot] Build bootctl for Android 8. MER#1947

Upstream changes:

[vendor/nxp/NXPNFCC_FW] NFC_NCIHALx_AR2000.09.00.0D_OpnSrc
[vendor/nxp/NXPNFCC_FW] Update README.md
[vendor/nxp/NXPNFCC_FW] Update README.md
[vendor/nxp/NXPNFCC_FW] Update README.md
[vendor/nxp/NXPNFCC_FW] NFC_NCIHALx_AR2000.09.00.0A_OpnSrc
[vendor/nxp/NXPNFCC_FW] NFC_NCIHALx_AR0800.9.0.10
[vendor/qcom/opensource/camera] CameraParameters: fix build with BOARD_VNDK_VERSION
[vendor/qcom/opensource/camera] msm8998: Update from AOSP
[vendor/qcom/opensource/camera] Revert "QCamera2:HAL :Changes to get the vsync event and presentation timestamp"
[vendor/qcom/opensource/camera] Revert "QCamera2:Compilation fix for OMR release"
[vendor/qcom/opensource/camera] Revert "QCamera2:QCameraDisplay:Merging fix of DisplayService transaction failed."
[vendor/qcom/opensource/camera] Revert "QCamera2:QCameraDisplay:Dynamic registration of display service."
[vendor/qcom/opensource/camera] fix display folder path
[vendor/qcom/opensource/camera] Fix dependencies for mm-camera-interface
[vendor/qcom/opensource/camera] fix build with BOARD_VNDK_VERSION
[vendor/qcom/opensource/camera] camera: fix build with BOARD_VNDK_VERSION
[vendor/qcom/opensource/camera] move the camera dumps to /data/vendor/camera
[vendor/qcom/opensource/camera] mm-camera: Change kernel version check for SoMC
[vendor/qcom/opensource/camera] QCamera2: HAL: Change media entity enumeration logic. Issue: Media entity enumeration logic not support kernel 4.9 Fix: Changes added to support media entity enumeration for both Kernel 4.9 and 4.4 version.
[device/sony/akari] reorder properties for DS devices
[device/sony/akari] remove prebuilt dtbo.img when TARGET_COMPILE_WITH_MSM_KERNEL is true
[device/sony/akari] set GSM capability for DS devices
[device/sony/apollo] reorder properties for DS devices
[device/sony/apollo] remove prebuilt dtbo.img when TARGET_COMPILE_WITH_MSM_KERNEL is true
[device/sony/apollo] remove unused Sensors Configuration
[device/sony/apollo] set GSM capability for DS devices
[device/sony/common] treble: add the packages needed for BOARD_VNDK_VERSION
[device/sony/common] vendor: increment vendor version
[device/sony/common] librqbalance: fix build with BOARD_VNDK_VERSION
[device/sony/common] power: fix build with BOARD_VNDK_VERSION
[device/sony/common] libpolyreg: Fix libcutils private headers
[device/sony/common] move the camera dumps to /data/vendor/camera
[device/sony/common] Revert "cnss-daemon.rc: set net_admin for cnss-daemon"
[device/sony/common] vendor: init: Add paths for k4.9
[device/sony/common] move the common SRC_CAMERA_HAL_DIR
[device/sony/common] data: add the configuration for sdm845
[device/sony/common] odm: packages: add sensors.sdm845
[device/sony/common] add cdsprcpd service
[device/sony/common] init.common.rc: Create dir for display
[device/sony/common] cnss-daemon.rc: set net_admin for cnss-daemon
[device/sony/common] switch Display HAL to our own branch
[device/sony/discovery] reorder properties for DS devices
[device/sony/discovery] set GSM capability for DS devices
[device/sony/dora] reorder properties for DS devices
[device/sony/kagura] reorder properties for DS devices
[device/sony/keyaki] reorder properties for DS devices
[device/sony/loire] remove the duplicate androidboot.console
[device/sony/loire] genfs_contexts: fix duplicate path
[device/sony/loire] init: Add paths for k4.9
[device/sony/loire] uevent: Add paths for k4.9
[device/sony/loire] platform: Add paths for k4.9
[device/sony/loire] sepolicy: Add paths for k4.9
[device/sony/maple] reorder properties for DS devices
[device/sony/pioneer] reorder properties for DS devices
[device/sony/pioneer] set GSM capability for DS devices
[device/sony/poplar] reorder properties for DS devices
[device/sony/sepolicy] sepolicy: avoid kernel 4.9 denials
[device/sony/sepolicy] sepolicy: avoid kernel 4.9 denials
[device/sony/sepolicy] sepolicy: avoid kernel 4.9 denials
[device/sony/sepolicy] sepolicy: Add paths for k4.9
[device/sony/sepolicy] add basic cdsprpcd permisisons
[device/sony/suzu] reorder properties for DS devices
[device/sony/tama] add A/B OTA dexopt support
[device/sony/tama] add PRODUCT_STATIC_BOOT_CONTROL_HAL
[device/sony/tama] ueventd.rc: Update paths for kernel 4.9
[device/sony/tama] remove the duplicate androidboot.console
[device/sony/tama] genfs_contexts: remove duplicate rmtfs_sharedmem
[device/sony/tone] sepolicy: avoid sde denials
[device/sony/tone] remove the duplicate androidboot.console
[device/sony/tone] genfs_contexts: remove duplicate sysfs_mdss_mdp_caps
[device/sony/tone] init: Add paths for k4.9
[device/sony/tone] platform: Add paths for k4.9
[device/sony/tone] ueventd: Add paths for k4.9
[device/sony/tone] sepolicy: Add paths for k4.9
[device/sony/yoshino] remove the duplicate androidboot.console
[device/sony/yoshino] sepolicy: Add paths for k4.9
[device/sony/yoshino] ueventd: Add paths for k4.9
[packages/apps/ExtendedSettings] ES: Migrate to AAPT2
[packages/apps/ExtendedSettings] ES: preference framework has moved out of v7 folder.
[packages/apps/ExtendedSettings] ES: Using private APIs does not require SDK guard.
[packages/apps/ExtendedSettings] ES: Grant access to private SDK APIs such as SystemProperties.
[packages/apps/ExtendedSettings] ES: set LOCAL_SDK_VERSION to current
[hardware/qcom/bt] bt: use TARGET_BOARD_AUTO to override qcom hals
[hardware/qcom/bt] bt: use TARGET_BOARD_AUTO to override qcom hals
[vendor/oss/repo_update] Сode alignment and duplicate removal
[vendor/oss/repo_update] Add support for exFAT file system to vold
[vendor/oss/repo_update] Fix bug Device that can't support adoptable storage cannot read the sdcard
[vendor/oss/repo_update] repo_update: Add odm check
[vendor/oss/repo_update] Revert "repo_update: Properly fetch and apply recovery "rotation logic""
[vendor/oss/repo_update] media: msm8996: bump 713242 patch version
[vendor/oss/repo_update] Add display HAL patch for night mode
[vendor/oss/repo_update] msm8996: fix build
[vendor/oss/repo_update] Add patches required to build using sdm845 hals and 4.9 kernel headers
[vendor/oss/timekeep] Don't use shell in make file
[vendor/oss/timekeep] Let TimeKeep use private platform APIs
[vendor/oss/timekeep] Timekeep: set LOCAL_SDK_VERSION to current
[vendor/oss/timekeep] fix build with BOARD_VNDK_VERSION
[vendor/oss/transpower] Bump up version (2.2.1)
[vendor/oss/transpower] Fix access to telephony-common lib and additional resources
[vendor/oss/transpower] Require access to hidden platform APIs
[vendor/oss/transpower] Bump app version (2.1.1)
[vendor/qcom/opensource/location] silence LOG_TAG macro redefined warning
[vendor/qcom/opensource/location] loc_api: include: Correct pointer type of message_table
[vendor/qcom/opensource/location] Revert "Speed, bearing and vertical accuracy must be read from Zpp Fix"
[vendor/qcom/opensource/location] fix build with BOARD_VNDK_VERSION
[kernel/sony/msm-4.4/kernel/drivers/staging/wlan-qc/qcacld-3.0] Android.mk: add SOMC_KERNEL_VERSION
[vendor/oss/cash] silence LOG_TAG macro redefined warning
[vendor/oss/cash] remove unused variables
[vendor/oss/cash] fix build with BOARD_VNDK_VERSION
[vendor/oss/fingerprint] Android.mk: Use SOMC_KERNEL_VERSION for path selection
[vendor/oss/fingerprint] Android.mk: Update sysfs path for k4.9
[vendor/oss/fingerprint] Fix warnings of unused parameters and variables
[vendor/oss/fingerprint] Remove cpp flags
[vendor/oss/projection] add LOCAL_PRIVATE_PLATFORM_APIS
[vendor/oss/projection] remove unused variables
[vendor/oss/projection] REVERTME: remove Android.bp

Change-Id: I67796aefac706378248cd01ee1ef816de8efa2bf
Signed-off-by: Franz-Josef Haider <franz.haider@jolla.com>