### PR TITLE
Adjust to rebased and moved libhybris.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
   <remote fetch="https://android.googlesource.com/" name="aosp" review="https://android-review.googlesource.com/"/>
-  <remote fetch="https://github.com/mer-hybris/" name="hybris" revision="master"/>
-  <remote fetch="https://github.com/krnlyng/" name="krnlyng"/>
+  <remote fetch="https://github.com/mer-hybris/" name="hybris"/>
   <remote fetch="https://github.com/mer-hybris/" name="hybris-patches" revision="hybris-sony-aosp-8.1.0_r35_20180714"/>
   <remote fetch="https://github.com/NXPNFCProject/" name="NXP"/>
   <remote fetch="https://github.com/sonyxperiadev/" name="sony"/>
@@ -14,7 +13,7 @@
   <project name="droid-hal-sony-nile" path="rpm" remote="hybris" revision="master"/>
   <project name="hybris-boot" path="hybris/hybris-boot" remote="hybris" revision="master"/>
   <project name="mer-kernel-check" path="hybris/mer-kernel-check" remote="hybris" revision="master"/>
-  <project name="libhybris-1" path="external/libhybris" remote="krnlyng" revision="android8-initial"/>
+  <project name="libhybris" path="external/libhybris" remote="hybris" revision="android8-initial"/>
   <project name="android_external_busybox_prebuilt" path="external/busybox" remote="hybris" revision="master"/>
   <project name="android_external_selinux_stubs" path="external/selinux_stubs" remote="hybris" revision="master"/>
   <project name="android_frameworks_av" path="frameworks/av" remote="hybris-patches" revision="hybris-sony-aosp-8.1.0_r35_20180714"/>

--- a/tagged-manifest.xml
+++ b/tagged-manifest.xml
@@ -2,9 +2,8 @@
 <manifest>
   <remote fetch="https://github.com/NXPNFCProject/" name="NXP"/>
   <remote fetch="https://android.googlesource.com/" name="aosp" review="https://android-review.googlesource.com/"/>
-  <remote fetch="https://github.com/mer-hybris/" name="hybris" revision="master"/>
+  <remote fetch="https://github.com/mer-hybris/" name="hybris"/>
   <remote fetch="https://github.com/mer-hybris/" name="hybris-patches" revision="hybris-sony-aosp-8.1.0_r35_20180714"/>
-  <remote fetch="https://github.com/krnlyng/" name="krnlyng"/>
   <remote fetch="https://github.com/sonyxperiadev/" name="sony"/>
   
   <default remote="aosp" revision="refs/tags/android-8.1.0_r35" sync-j="4"/>
@@ -71,7 +70,7 @@
   <project name="hardware-qcom-wlan" path="vendor/qcom/opensource/wlan" remote="sony" revision="d8a7fe7303cdc5f1087a186cd95388c979fc4dad" upstream="master"/>
   <project name="hybris-boot" path="hybris/hybris-boot" remote="hybris" revision="bd4134fec42b66c9e33ec287a59b7dabe5ae33b2" upstream="master"/>
   <project name="kernel/tests" revision="fa4729e5d6aeba19cc9ea0b3cbd4eb085865beda" upstream="refs/tags/android-8.1.0_r35"/>
-  <project name="libhybris-1" path="external/libhybris" remote="krnlyng" revision="067914df53f7261ef0a884f9a505f598805a7ec8" upstream="android8-initial"/>
+  <project name="libhybris" path="external/libhybris" remote="hybris" revision="3c96694c1f534fa27484f72c83361bf77ebd2933" upstream="android8-initial"/>
   <project name="macaddrsetup" path="vendor/oss/macaddrsetup" remote="sony" revision="bd7ce4eb762bb76cfddb4d4268352f8d3a71edd9" upstream="master"/>
   <project name="mer-kernel-check" path="hybris/mer-kernel-check" remote="hybris" revision="39b5ad47853e7cafe11c81c0ba4d71ba550f31c3" upstream="master"/>
   <project name="packages-apps-FMRadio" path="packages/apps/FMRadio" remote="sony" revision="680e46c71260e0bbd9517b82a9b7be7902745698" upstream="master"/>


### PR DESCRIPTION
[external/libhybris] point to mer-hybris android8-initial branch since it was rebased and moved. JB#43038