### PR TITLE
Update manifest

### DIFF
--- a/tagged-manifest.xml
+++ b/tagged-manifest.xml
@@ -31,7 +31,7 @@
   <project name="android_hardware_qcom_display" path="hardware/qcom/display" remote="hybris-patches" revision="d3779468c4821b0914c5d67088577b5874a3633e" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
   <project name="android_hardware_qcom_gps" path="hardware/qcom/gps" remote="hybris-patches" revision="663dbe453987314ac5831efd07897b3e929d8023" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
   <project name="android_hardware_qcom_media" path="hardware/qcom/media" remote="hybris-patches" revision="e01e032feb6df056104beda1cf682afb5ef98a2f" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
-  <project name="android_kernel_sony_msm" path="kernel/sony/msm-4.4/kernel" remote="hybris-patches" revision="f67d67d45b835ac1a5356cc158dc77e924f8e2b6" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
+  <project name="android_kernel_sony_msm" path="kernel/sony/msm-4.4/kernel" remote="hybris-patches" revision="11ce243044810e00370108ca69c73e54ab43189c" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
   <project name="android_system_core" path="system/core" remote="hybris-patches" revision="8b9d9f1397390e2db1fd8421211c71208931afd7" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
   <project name="android_system_nfc" path="system/nfc" remote="hybris-patches" revision="0e036edb77546f74a2c7eea9c5506415cb1dde2e" upstream="hybris-sony-aosp-8.1.0_r35_20180714"/>
   <project name="camera" path="vendor/qcom/opensource/camera" remote="sony" revision="dc9af5d36009caa60b9b01a256a7f8ce4c1897f1" upstream="aosp/LA.UM.6.4.r1"/>


### PR DESCRIPTION
[kernel/sony/msm-4.4/kernel] Hybris friendly defconfig for discovery. MER#1955
[kernel/sony/msm-4.4/kernel] Enable CONFIG_BT_HCIVHCI for discovery. JB#43036
[kernel/sony/msm-4.4/kernel] Enable CONFIG_BT_HCIVHCI for pioneer. JB#43036
[kernel/sony/msm-4.4/kernel] Merge patches from sony-aosp-8.1.0_r35_20181003. MER#1955

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>