### PR TITLE
Update manifest

### DIFF
--- a/tagged-manifest.xml
+++ b/tagged-manifest.xml
@@ -32,7 +32,7 @@
   <project name="android_hardware_qcom_display" path="hardware/qcom/display" remote="hybris-patches" revision="a7be416c0d8f383138964a84c9f8668e213b935b" upstream="hybris-sony-aosp-8.1.0_r47_20181015"/>
   <project name="android_hardware_qcom_gps" path="hardware/qcom/gps" remote="hybris-patches" revision="663dbe453987314ac5831efd07897b3e929d8023" upstream="hybris-sony-aosp-8.1.0_r47_20181015"/>
   <project name="android_hardware_qcom_media" path="hardware/qcom/media" remote="hybris-patches" revision="b013e6f93bdf0257275136a2fa4e16c2e9f10bae" upstream="hybris-sony-aosp-8.1.0_r47_20181015"/>
-  <project name="android_kernel_sony_msm" path="kernel/sony/msm-4.4/kernel" remote="hybris-patches" revision="44846218eff3810fd6d93282e9f2077812945313" upstream="hybris-sony-aosp-8.1.0_r47_20181015"/>
+  <project name="android_kernel_sony_msm" path="kernel/sony/msm-4.4/kernel" remote="hybris-patches" revision="8b859ffebb6c0f263d9f89dd9e72b41611141ce3" upstream="hybris-sony-aosp-8.1.0_r47_20181015"/>
   <project name="android_system_core" path="system/core" remote="hybris-patches" revision="30b62bba97dd1cb1192470954aa2b649b7142b0a" upstream="hybris-sony-aosp-8.1.0_r47_20181015"/>
   <project name="android_system_nfc" path="system/nfc" remote="hybris-patches" revision="0e036edb77546f74a2c7eea9c5506415cb1dde2e" upstream="hybris-sony-aosp-8.1.0_r47_20181015"/>
 
@@ -72,10 +72,10 @@
   <project clone-depth="1" name="device/google/vrservices" revision="b290ba549b38447937773e3698e4678015550684" upstream="refs/tags/android-8.1.0_r47"/>
   <project name="device/google/wahoo" revision="25e22473e5c306732b4cf142f31b89381f4cfb44" upstream="refs/tags/android-8.1.0_r47"/>
   <project name="device/sample" revision="509608c76570d623c05952c8eecdc2868ca8a952" upstream="refs/tags/android-8.1.0_r47"/>
-  <project name="droid-hal-sony-nile" path="rpm" remote="hybris" revision="7ad7226200501f02385f9c6d85b4bf80eb4ff40d" upstream="master"/>
+  <project name="droid-hal-sony-nile" path="rpm" remote="hybris" revision="afc3859d4c777c11d655d80bd4cf50e4c474387f" upstream="master"/>
   <project name="hardware-qcom-display" path="hardware/qcom/display/sde" remote="sony" revision="04a62d555aaffa906dd60b7c973f1fe6f40bb985" upstream="aosp/LA.UM.6.3.r1"/>
   <project name="hardware-qcom-wlan" path="vendor/qcom/opensource/wlan" remote="sony" revision="d8a7fe7303cdc5f1087a186cd95388c979fc4dad" upstream="master"/>
-  <project name="hybris-boot" path="hybris/hybris-boot" remote="hybris" revision="ad32797d6470ad76d8def9964473a572845c4eae" upstream="master"/>
+  <project name="hybris-boot" path="hybris/hybris-boot" remote="hybris" revision="e2bb43cd21c8b7950e47f79353f7a02f297c5ecc" upstream="master"/>
   <project name="kernel/tests" revision="fa4729e5d6aeba19cc9ea0b3cbd4eb085865beda" upstream="refs/tags/android-8.1.0_r47"/>
   <project name="libhybris" path="external/libhybris" remote="hybris" revision="3c96694c1f534fa27484f72c83361bf77ebd2933" upstream="android8-initial"/>
   <project name="macaddrsetup" path="vendor/oss/macaddrsetup" remote="sony" revision="6010d6cd63dedafc124e6b9e3769511aa812d2be" upstream="master"/>


### PR DESCRIPTION
[hybris/hybris-boot] Add support for voyager devices. JB#43407
[rpm] Add support for voyager devices. JB#43407
[kernel/sony/msm-4.4/kernel] hybris friendly defconfig for voyager. JB#43407
[kernel/sony/msm-4.4/kernel] Sync discovery and pioneer kernel configs. JB#43407
[frameworks/av] Support ISO setting on HAL3 devices under API1 on Qualcomm devices. Fixes JB#42952