### PR TITLE
Update manifest

### DIFF
--- a/tagged-manifest.xml
+++ b/tagged-manifest.xml
@@ -32,7 +32,7 @@
   <project name="android_hardware_qcom_display" path="hardware/qcom/display" remote="hybris-patches" revision="a7be416c0d8f383138964a84c9f8668e213b935b" upstream="hybris-sony-aosp-8.1.0_r47_20181015"/>
   <project name="android_hardware_qcom_gps" path="hardware/qcom/gps" remote="hybris-patches" revision="663dbe453987314ac5831efd07897b3e929d8023" upstream="hybris-sony-aosp-8.1.0_r47_20181015"/>
   <project name="android_hardware_qcom_media" path="hardware/qcom/media" remote="hybris-patches" revision="b013e6f93bdf0257275136a2fa4e16c2e9f10bae" upstream="hybris-sony-aosp-8.1.0_r47_20181015"/>
-  <project name="android_kernel_sony_msm" path="kernel/sony/msm-4.4/kernel" remote="hybris-patches" revision="239264df081218393713cf4024e1049fd234480b" upstream="hybris-sony-aosp-8.1.0_r47_20181015"/>
+  <project name="android_kernel_sony_msm" path="kernel/sony/msm-4.4/kernel" remote="hybris-patches" revision="51fce872214f0c0423d0f64c835ba355a6217330" upstream="hybris-sony-aosp-8.1.0_r47_20181015"/>
   <project name="android_system_core" path="system/core" remote="hybris-patches" revision="30b62bba97dd1cb1192470954aa2b649b7142b0a" upstream="hybris-sony-aosp-8.1.0_r47_20181015"/>
   <project name="android_system_nfc" path="system/nfc" remote="hybris-patches" revision="0e036edb77546f74a2c7eea9c5506415cb1dde2e" upstream="hybris-sony-aosp-8.1.0_r47_20181015"/>
 


### PR DESCRIPTION
[kernel/sony/msm-4.4/kernel] add CONFIG_SQUASHFS_XATTR=y for xattr support in squashfs filesystems. JB#43851