### PR TITLE
Update manifest

### DIFF
--- a/tagged-manifest.xml
+++ b/tagged-manifest.xml
@@ -75,9 +75,9 @@
   <project name="droid-hal-sony-nile" path="rpm" remote="hybris" revision="afc3859d4c777c11d655d80bd4cf50e4c474387f" upstream="master"/>
   <project name="hardware-qcom-display" path="hardware/qcom/display/sde" remote="sony" revision="04a62d555aaffa906dd60b7c973f1fe6f40bb985" upstream="aosp/LA.UM.6.3.r1"/>
   <project name="hardware-qcom-wlan" path="vendor/qcom/opensource/wlan" remote="sony" revision="d8a7fe7303cdc5f1087a186cd95388c979fc4dad" upstream="master"/>
-  <project name="hybris-boot" path="hybris/hybris-boot" remote="hybris" revision="e2bb43cd21c8b7950e47f79353f7a02f297c5ecc" upstream="master"/>
+  <project name="hybris-boot" path="hybris/hybris-boot" remote="hybris" revision="04bf4870a4a8301c0248e56e2ad69b1e126d214c" upstream="master"/>
   <project name="kernel/tests" revision="fa4729e5d6aeba19cc9ea0b3cbd4eb085865beda" upstream="refs/tags/android-8.1.0_r47"/>
-  <project name="libhybris" path="external/libhybris" remote="hybris" revision="3c96694c1f534fa27484f72c83361bf77ebd2933" upstream="android8-initial"/>
+  <project name="libhybris" path="external/libhybris" remote="hybris" revision="6ef304cfafa74d902e4ea927c30f7ae45a410e45" upstream="android8-initial"/>
   <project name="macaddrsetup" path="vendor/oss/macaddrsetup" remote="sony" revision="eda05ed28821d91a38f98c471f92fdc56f6c7714" upstream="master"/>
   <project name="mer-kernel-check" path="hybris/mer-kernel-check" remote="hybris" revision="39b5ad47853e7cafe11c81c0ba4d71ba550f31c3" upstream="master"/>
   <project name="packages-apps-FMRadio" path="packages/apps/FMRadio" remote="sony" revision="680e46c71260e0bbd9517b82a9b7be7902745698" upstream="master"/>


### PR DESCRIPTION
[external/libhybris] Update to libhybris with hwc2 support. JB#42317
[hybris/hybris-boot] Build libhwc2_compat_layer for hwc2 support on android 8 based adaptation. JB#42317