### PR TITLE
Update manifest

### DIFF
--- a/tagged-manifest.xml
+++ b/tagged-manifest.xml
@@ -9,7 +9,7 @@
   
   <default remote="aosp" revision="refs/tags/android-8.1.0_r52" sync-j="4"/>
   
-  <project name="NXPNFCC_FW" path="vendor/nxp/NXPNFCC_FW" remote="NXP" revision="a0d878573f57e1f55f0e9fc42c21821e36c16d52" upstream="master"/>
+  <project name="NXPNFCC_FW" path="vendor/nxp/NXPNFCC_FW" remote="NXP" revision="756ae655b599cdf148983cdc900651590c94f90d" upstream="master"/>
   <project name="android_bionic" path="bionic" remote="hybris-patches" revision="8bd8f3cafb1bd147f167d87f885ee93a6b58bb01" upstream="hybris-sony-aosp-8.1.0_r52_20190206"/>
   <project name="android_build" path="build/make" remote="hybris-patches" revision="086cab4994b71cef8c7ab0121ded1a313e5e14e8" upstream="hybris-sony-aosp-8.1.0_r52_20190206">
     <copyfile dest="Makefile" src="core/root.mk"/>
@@ -36,12 +36,12 @@
   <project name="android_system_core" path="system/core" remote="hybris-patches" revision="3a94ff983623f83393b7ca4818b9fd941d6901ab" upstream="hybris-sony-aosp-8.1.0_r52_20190206"/>
   <project name="android_system_nfc" path="system/nfc" remote="sony-patches" revision="d98fb8fdcb1cb55f53560b12c2420979dd00efec" upstream="droid-src-sony-aosp-8.1.0_r52_20190206"/>
   <project name="android_system_vold" path="system/vold" remote="sony-patches" revision="a351c39be1b5148ad73e8f8e6d56b691366ba5be" upstream="droid-src-sony-aosp-8.1.0_r52_20190206"/>
-  <project name="camera" path="vendor/qcom/opensource/camera" remote="sony" revision="b918437410698035cb1f0fe51e6721ae808de1c5" upstream="aosp/LA.UM.6.4.r1"/>
+  <project name="camera" path="vendor/qcom/opensource/camera" remote="sony" revision="bf46a89fbb82e1913e949991d4bcd01c95c895a5" upstream="aosp/LA.UM.6.4.r1"/>
   <project name="device-sony-akari" path="device/sony/akari" remote="sony" revision="521cad43e160ffd72f4c08cdafe412c1a42650e4" upstream="o-mr1"/>
   <project name="device-sony-akatsuki" path="device/sony/akatsuki" remote="sony" revision="1c8a27b35ac69219559d83d61ec1e7adae3fb21e" upstream="o-mr1"/>
   <project name="device-sony-apollo" path="device/sony/apollo" remote="sony" revision="feb2210169ca22487922af094770000d98aa1e32" upstream="o-mr1"/>
   <project name="device-sony-blanc" path="device/sony/blanc" remote="sony" revision="c42041ee34bd841eb10930bef179b8b80744b530" upstream="o-mr1"/>
-  <project name="device-sony-common" path="device/sony/common" remote="sony-patches" revision="c8abf76f61c081ef97fd618ffc7c654dfe33e6c3" upstream="droid-src-sony-aosp-8.1.0_r52_20190206"/>
+  <project name="device-sony-common" path="device/sony/common" remote="sony-patches" revision="052bdd17cc272170b09173c2fe50b0c4a9b35bff" upstream="droid-src-sony-aosp-8.1.0_r52_20190206"/>
   <project name="device-sony-common-headers" path="kernel/sony/msm-4.4/common-headers" remote="sony" revision="c7e52e0c6cedf83c15d938688365d0a6b6bbd3fe" upstream="aosp/LA.UM.6.4.r1"/>
   <project name="device-sony-discovery" path="device/sony/discovery" remote="sony" revision="75f84718e827166e85fa60a04b41886b30a7b053" upstream="o-mr1"/>
   <project name="device-sony-dora" path="device/sony/dora" remote="sony" revision="a91b3065d7751584f0dbc8018970a0b13382a776" upstream="o-mr1"/>
@@ -54,7 +54,7 @@
   <project name="device-sony-nile" path="device/sony/nile" remote="hybris-patches" revision="c96620c47ea5d387bd1d70361ae69180cf2803d8" upstream="hybris-sony-aosp-8.1.0_r52_20190206"/>
   <project name="device-sony-pioneer" path="device/sony/pioneer" remote="sony" revision="c300d6712e0016a5b21b6a4909742369d2d49d56" upstream="o-mr1"/>
   <project name="device-sony-poplar" path="device/sony/poplar" remote="sony" revision="2e694b40dab5b9daca5bd237a6e9535d7b5b945d" upstream="o-mr1"/>
-  <project name="device-sony-sepolicy" path="device/sony/sepolicy" remote="sony" revision="7b80b5c368343f897b50d3935ff4f8dedbcf3ea6" upstream="o-mr1"/>
+  <project name="device-sony-sepolicy" path="device/sony/sepolicy" remote="sony" revision="403ac714d28132804670a85a53667a434f6aaad4" upstream="o-mr1"/>
   <project name="device-sony-suzu" path="device/sony/suzu" remote="sony" revision="cefb58f43d20ed7b58103c7a521e27b08b195444" upstream="o-mr1"/>
   <project name="device-sony-tama" path="device/sony/tama" remote="sony" revision="eef23c8e06989cc2915b240f9d0aee3c4a3adb87" upstream="o-mr1"/>
   <project name="device-sony-tone" path="device/sony/tone" remote="sony" revision="08c6e670c1166de4330c820fa78187d92bbb5a30" upstream="o-mr1"/>
@@ -72,7 +72,7 @@
   <project name="device/sample" revision="509608c76570d623c05952c8eecdc2868ca8a952" upstream="refs/tags/android-8.1.0_r52"/>
   <project name="droid-hal-sony-nile" path="rpm" remote="hybris" revision="1d266024dde81c32caeccbab6978426038be326c" upstream="master"/>
   <project name="hardware-qcom-display" path="hardware/qcom/display/msmfb" remote="sony" revision="f306f78eeb7884e1266078266e170170c23fc1c0" upstream="aosp/LA.UM.6.3.r1"/>
-  <project name="hardware-qcom-display" path="hardware/qcom/display/sde" remote="sony" revision="5b77cd2c88bdeda382f05d7c2005af54cbe87762" upstream="aosp/LA.UM.7.3.r1"/>
+  <project name="hardware-qcom-display" path="hardware/qcom/display/sde" remote="sony" revision="9c859d4816c6cfba691beb03b675fc3eb095b2ba" upstream="aosp/LA.UM.7.3.r1"/>
   <project name="hardware-qcom-wlan" path="vendor/qcom/opensource/wlan" remote="sony" revision="6351125ec900f421276213a2a0d336cfc6268042" upstream="master"/>
   <project name="hybris-boot" path="hybris/hybris-boot" remote="hybris" revision="0acfadb2cb4afdca5154b48dea4f5bab706c2e3f" upstream="master"/>
   <project name="kernel/tests" revision="fa4729e5d6aeba19cc9ea0b3cbd4eb085865beda" upstream="refs/tags/android-8.1.0_r52"/>
@@ -593,7 +593,7 @@
     <linkfile dest="repo_update.sh" src="repo_update.sh"/>
   </project>
   <project name="thermanager" path="vendor/oss/thermanager" remote="sony" revision="87297db29b81ae9dedb386f75db8457e871a5a59" upstream="master"/>
-  <project name="timekeep" path="vendor/oss/timekeep" remote="sony" revision="20d51146bf3668e570166b8c6165887736cfe276" upstream="master"/>
+  <project name="timekeep" path="vendor/oss/timekeep" remote="sony" revision="9377c4aa8a84a0bb8be657785b2b7fe9423c957d" upstream="master"/>
   <project name="toolchain/binutils" revision="a4125cf8aeab9dfeac00f1bda80645987897152f" upstream="refs/tags/android-8.1.0_r52"/>
   <project name="transpower" path="vendor/oss/transpower" remote="sony" revision="47700dfca36b1b3d69708b5288b5a18059d7922d" upstream="android-8.1.0_r35"/>
   <project name="vendor-broadcom-bt-fm" path="vendor/broadcom/bt-fm" remote="sony" revision="2da2991694277c0e29782fbadffe69027adeb09a" upstream="master"/>
@@ -608,8 +608,8 @@
   <project name="vendor-qcom-opensource-wlan-fw-api" path="kernel/sony/msm-4.4/kernel/drivers/staging/wlan-qc/fw-api" remote="sony" revision="fe41c8d61e096501b8de937dac684008d667b8a7" upstream="aosp/LA.UM.7.3.r1"/>
   <project name="vendor-qcom-opensource-wlan-qca-wifi-host-cmn" path="kernel/sony/msm-4.4/kernel/drivers/staging/wlan-qc/qca-wifi-host-cmn" remote="sony" revision="8becfc0299c98d8d509de53773e732714ec16148" upstream="aosp/LA.UM.7.3.r1"/>
   <project name="vendor-qcom-opensource-wlan-qcacld-3.0" path="kernel/sony/msm-4.4/kernel/drivers/staging/wlan-qc/qcacld-3.0" remote="sony" revision="8dcf1fbf8bbfadbe6fbad47f9b9389f41221477d" upstream="aosp/LA.UM.7.3.r1"/>
-  <project name="vendor-sony-oss-cash" path="vendor/oss/cash" remote="sony" revision="65d04f688a41599821f9d33a080509784b24e1de" upstream="master"/>
-  <project name="vendor-sony-oss-fingerprint" path="vendor/oss/fingerprint" remote="sony" revision="82a274e02032cf4260c142490ea486e56cc98aa6" upstream="master"/>
+  <project name="vendor-sony-oss-cash" path="vendor/oss/cash" remote="sony" revision="b47a64eaa434ab3121720df01f7be40222cd2ea9" upstream="master"/>
+  <project name="vendor-sony-oss-fingerprint" path="vendor/oss/fingerprint" remote="sony" revision="43483646abcf8a0d4db5d1a8131611d0d0a16fcb" upstream="master"/>
   <project name="vendor-sony-oss-projection" path="vendor/oss/projection" remote="sony" revision="ea763867a7fa1b859d310d08fac4fd4763f0b39a" upstream="master"/>
   
   <repo-hooks enabled-list="pre-upload" in-project="platform/tools/repohooks"/>


### PR DESCRIPTION
[vendor/qcom/opensource/camera] QCamera2: Increase maximum BLOB buffers for HDR. JB#46793
[device/sony/common] do not include the sscrpcd service on legacy devices
[device/sony/sepolicy] properties: Sort and increase spacing
[device/sony/sepolicy] Label persist.vendor.net.* props, grant access
[device/sony/sepolicy] props: Label renamed timeadjust prop
[device/sony/sepolicy] Label CASH props and grant access
[device/sony/sepolicy] Label vendor-prefixed ES props, grant access
[hardware/qcom/display/sde] sdm: core: fb: add basic detection of the primary display
[hardware/qcom/display/sde] sdm: core: add property to skip creating extension interface
[hardware/qcom/display/sde] sdm: hwc2: Added property to disable skipping client
[vendor/oss/timekeep] timekeep.rc: Drop root privileges
[vendor/oss/timekeep] Use persist.vendor.timeadjust for prop
[vendor/oss/cash] Use persist.vendor.cash.* for props
[vendor/oss/cash] cashsvr.rc: Use vendor prefix
[vendor/oss/fingerprint] BiometricsFingerprint: Fix indentation inconsistency.
[vendor/oss/fingerprint] BiometricsFingerprint: Change static fns to members, drop thisPtr.
[vendor/oss/fingerprint] egistec: Simplify epoll_event initialization.
[vendor/oss/fingerprint] common: Simplify epoll_event initialization.
[vendor/oss/fingerprint] imp: Rewrite capture/wait return values.
[vendor/oss/fingerprint] BiometricsFingerprint: Let the service restart the HAL on fatal errors.
[vendor/oss/fingerprint] tama: Continue capturing when return code equals 3.
[vendor/oss/fingerprint] BiometricsFingerprint: Clean up duplicate headers.
[vendor/oss/fingerprint] tama: Swap sensor_wake and wait_finger_lost (again), poll on IRQ.
[vendor/oss/fingerprint] tama: Put sensor in awake state before blocking on finger events.
[vendor/oss/fingerprint] tama: Keep awake for as long as possible before entering capure state.
[vendor/oss/fingerprint] BiometricsFingerprint: Transition to idle state before raising events.
[vendor/oss/fingerprint] BiometricsFingerprint: Do not report fingerprints when retrieve fails.
[vendor/oss/fingerprint] fpc_imp: Close event fds when freeing data memory.
[vendor/oss/fingerprint] BiometricsFingerprint: Fully abort authentication when auth_step fails.
[vendor/oss/fingerprint] Restructure and namespace HALs in preparation for Ganges Egistec.
[vendor/oss/fingerprint] BiometricsFingerprint: Simplify namespace to follow Egistec structure.
[vendor/oss/fingerprint] Egistec: Ganges: Initial datastructures, command-ids and TZ set-up.
[vendor/oss/fingerprint] Egistec: Ganges: Implement ION buffer allocation and handling.
[vendor/oss/fingerprint] Egistec: Nile: Extract thread state management into separate class.
[vendor/oss/fingerprint] Egistec: Nile: Use .reserve rather than .resize when allocating prints.
[vendor/oss/fingerprint] Egistec: Ganges: Implement async enroll loop.
[vendor/oss/fingerprint] Egistec: Ganges: Implement fingerprint deletion.
[vendor/oss/fingerprint] Egistec: Ganges: Initialize rng with a seed that's not 1.
[vendor/oss/fingerprint] Egistec: Ganges: Finish line! Implement authentication sequence.
[vendor/oss/fingerprint] WorkerThread: Notify handler before entering idle state.
[vendor/oss/fingerprint] Egistec: Ganges: Add state cleanup, fix concurrency issues.
[vendor/oss/fingerprint] Revert "REVERTME: a horrible workaround for the stuck ET51x sensor"
[vendor/oss/fingerprint] QSEEKeymasterTrustlet: Check status code when retrieving key.
[vendor/oss/fingerprint] Android.mk: Add PRODUCT_PLATFORM_SOD build barrier

Change-Id: Iee7e2651297b2357ca55c5fffc9ea05adabac865