### PR TITLE
Update manifest

### DIFF
--- a/tagged-manifest.xml
+++ b/tagged-manifest.xml
@@ -32,7 +32,7 @@
   <project name="android_hardware_qcom_display" path="hardware/qcom/display" remote="sony-patches" revision="a7be416c0d8f383138964a84c9f8668e213b935b" upstream="droid-src-sony-aosp-8.1.0_r52_20190206"/>
   <project name="android_hardware_qcom_gps" path="hardware/qcom/gps" remote="sony-patches" revision="31fb126c9c30d20036b08c6c1663980a1e6c30f1" upstream="droid-src-sony-aosp-8.1.0_r52_20190206"/>
   <project name="android_hardware_qcom_media" path="hardware/qcom/media" remote="sony-patches" revision="ce9e3ad83a958bd3bb8c66ef4b0254fb1883d5b0" upstream="droid-src-sony-aosp-8.1.0_r52_20190206"/>
-  <project name="android_kernel_sony_msm" path="kernel/sony/msm-4.4/kernel" remote="hybris-patches" revision="a56820383f6d56bf1854d949e6e3b4ebf9018c2a" upstream="hybris-sony-aosp-8.1.0_r52_20190206"/>
+  <project name="android_kernel_sony_msm" path="kernel/sony/msm-4.4/kernel" remote="hybris-patches" revision="bd30e701d6b7999a23a7a031d5e3a33dded65ecb" upstream="hybris-sony-aosp-8.1.0_r52_20190206"/>
   <project name="android_system_core" path="system/core" remote="hybris-patches" revision="3a94ff983623f83393b7ca4818b9fd941d6901ab" upstream="hybris-sony-aosp-8.1.0_r52_20190206"/>
   <project name="android_system_nfc" path="system/nfc" remote="sony-patches" revision="d98fb8fdcb1cb55f53560b12c2420979dd00efec" upstream="droid-src-sony-aosp-8.1.0_r52_20190206"/>
   <project name="android_system_vold" path="system/vold" remote="sony-patches" revision="a351c39be1b5148ad73e8f8e6d56b691366ba5be" upstream="droid-src-sony-aosp-8.1.0_r52_20190206"/>


### PR DESCRIPTION
[kernel/sony/msm-4.4/kernel] CVE-2019-10538: Fix QualPwn remote vulnerability. JB#46888
[kernel/sony/msm-4.4/kernel] Upstream updates to Linux 4.4.185 level. JB#46888