### PR TITLE
Update manifest

### DIFF
--- a/tagged-manifest.xml
+++ b/tagged-manifest.xml
@@ -27,7 +27,7 @@
   <project name="android_hardware_qcom_keymaster" path="hardware/qcom/keymaster" remote="sony-patches" revision="140e47c0deac29b4fe12408f450ba8200aa469bb" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_hardware_qcom_media" path="hardware/qcom/media" remote="sony-patches" revision="c35f8b426620c458c94048e55a884a9c0b91b1e4" upstream="sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_hardware_ril" path="hardware/ril" remote="sony-patches" revision="4e15283fb76b9af5c286dda4cdd2e57e9e22ed6c" upstream="sony-aosp-6.0.1_r80-20170902"/>
-  <project name="android_kernel_sony_msm" path="kernel/sony/msm" remote="hybris-patches" revision="b09855f3b57bf0b027d504fbd0552415c346e1f0" upstream="hybris-sony-aosp-6.0.1_r80-20170902"/>
+  <project name="android_kernel_sony_msm" path="kernel/sony/msm" remote="hybris-patches" revision="52968e6c82d248b29c399b12ec0fcb1a58e88498" upstream="hybris-sony-aosp-6.0.1_r80-20170902"/>
   <project name="android_system_core" path="system/core" remote="hybris-patches" revision="b50d69af06f9d3c4d2475af18ed2f245b4c621fb" upstream="hybris-sony-aosp-6.0.1_r80-20170902"/>
   <project name="camera" path="hardware/qcom/camera" remote="sony" revision="b66cda07a10d0ff2b043f6d391d62d938a1cf203" upstream="aosp/LA.BR.1.3.3_rb2.14"/>
   <project name="device-sony-common" path="device/sony/common" remote="hybris-patches" revision="43097e0a590d45dad286aba2003001c2d596749b" upstream="hybris-sony-aosp-6.0.1_r80-20170902"/>


### PR DESCRIPTION
[kernel/sony/msm] Upstream patch for CVE-2019-11477. Fixes JB#46355
[kernel/sony/msm] Upstream patch for CVE-2019-11478. Fixes JB#46355
[kernel/sony/msm] Upstream patch for CVE-2019-11479. Fixes JB#46355

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>