### PR TITLE
manifest: Add patch for sepolicy to add dbus class.

### DIFF
--- a/tagged-manifest.xml
+++ b/tagged-manifest.xml
@@ -699,7 +699,7 @@
   <project groups="device" name="vendor-sony-oss-projection" path="vendor/oss/projection" remote="sony" revision="ea763867a7fa1b859d310d08fac4fd4763f0b39a" upstream="master"/>
   <project groups="device" name="vendor-sony-oss-simdetect" path="vendor/oss/simdetect" remote="sony" revision="743c35040a50043c96c7628cece489da24974729" upstream="master"/>
 
-  <project name="droid-src-sony-ganges-pie" path="rpm" remote="hybris" upstream="master" revision="3a08404891778d75d1fe8ac799e81822f0236eb6"/>
+  <project name="droid-src-sony-ganges-pie" path="rpm" remote="hybris" upstream="master" revision="7c22463ba3a67bb9395d41096cfbe333e9480b1c"/>
  
   <repo-hooks enabled-list="pre-upload" in-project="platform/tools/repohooks"/>
 </manifest>


### PR DESCRIPTION
[manifest] Add patch for sepolicy to add dbus class. JB#47185

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>