### PR TITLE
Updates from upstream to 4.4.194 version.

### DIFF
--- a/tagged-manifest.xml
+++ b/tagged-manifest.xml
@@ -32,7 +32,7 @@
   <project name="android_hardware_qcom_display" path="hardware/qcom/display" remote="sony-patches" revision="a7be416c0d8f383138964a84c9f8668e213b935b" upstream="droid-src-sony-aosp-8.1.0_r52_20190206"/>
   <project name="android_hardware_qcom_gps" path="hardware/qcom/gps" remote="sony-patches" revision="31fb126c9c30d20036b08c6c1663980a1e6c30f1" upstream="droid-src-sony-aosp-8.1.0_r52_20190206"/>
   <project name="android_hardware_qcom_media" path="hardware/qcom/media" remote="sony-patches" revision="ce9e3ad83a958bd3bb8c66ef4b0254fb1883d5b0" upstream="droid-src-sony-aosp-8.1.0_r52_20190206"/>
-  <project name="android_kernel_sony_msm" path="kernel/sony/msm-4.4/kernel" remote="hybris-patches" revision="fcea24195656920333bf5bf6a6db1388ca60f8b0" upstream="hybris-sony-aosp-8.1.0_r52_20190206"/>
+  <project name="android_kernel_sony_msm" path="kernel/sony/msm-4.4/kernel" remote="hybris-patches" revision="32bcf194b58989532816d69c8301563b0a396b3c" upstream="hybris-sony-aosp-8.1.0_r52_20190206"/>
   <project name="android_system_core" path="system/core" remote="hybris-patches" revision="3a94ff983623f83393b7ca4818b9fd941d6901ab" upstream="hybris-sony-aosp-8.1.0_r52_20190206"/>
   <project name="android_system_nfc" path="system/nfc" remote="sony-patches" revision="d98fb8fdcb1cb55f53560b12c2420979dd00efec" upstream="droid-src-sony-aosp-8.1.0_r52_20190206"/>
   <project name="android_system_vold" path="system/vold" remote="sony-patches" revision="a351c39be1b5148ad73e8f8e6d56b691366ba5be" upstream="droid-src-sony-aosp-8.1.0_r52_20190206"/>
@@ -78,7 +78,7 @@
   <project name="kernel/tests" revision="fa4729e5d6aeba19cc9ea0b3cbd4eb085865beda" upstream="refs/tags/android-8.1.0_r52"/>
   <project name="libhybris" path="external/libhybris" remote="hybris" revision="e0aec2df382668490c729afa71c2a2225f9a062a" upstream="master"/>
   <project name="macaddrsetup" path="vendor/oss/macaddrsetup" remote="sony" revision="d413798801a15dc5633b2beb17852d39e608dc0a" upstream="master"/>
-  <project name="mer-kernel-check" path="hybris/mer-kernel-check" remote="hybris" revision="bd73c3e167812f6310faad7ae2e08de9df5944bb" upstream="master"/>
+  <project name="mer-kernel-check" path="hybris/mer-kernel-check" remote="hybris" revision="5b392d411823d504e502fc0a219035934140b04a" upstream="master"/>
   <project name="packages-apps-FMRadio" path="packages/apps/FMRadio" remote="sony" revision="680e46c71260e0bbd9517b82a9b7be7902745698" upstream="master"/>
   <project name="packages_apps_ExtendedSettings" path="packages/apps/ExtendedSettings" remote="sony" revision="546cfb034b416c608add6c561005410f05efd1fe" upstream="o-mr1"/>
   <project name="platform/art" path="art" revision="7f13ce4d95e2f8e38a82021058025509b7e994df" upstream="refs/tags/android-8.1.0_r52"/>


### PR DESCRIPTION
[kernel-check] Remove extra kernel version from version check.
[kernel] Updates from upstream to 4.4.194 version. Fixes JB#48527

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>