### PR TITLE
manifest: temporarily introduce manifest versioning

### DIFF
--- a/tagged-manifest.xml
+++ b/tagged-manifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
+  <!-- incremental version bump: droid-src-sony-aosp-10/1.12.0 -->
   <remote fetch="https://github.com/mer-hybris" name="hybris"/>
   <include name="tagged-localbuild.xml"/>
   <project name="droid-src-sony" path="rpm" remote="hybris" revision="113ac5f7c357249e9be86dede4dd692e2457e9e3"/>


### PR DESCRIPTION
Required due to CI intricacies as temporary solution for manifests that include a tagged-localbuild.xml