### PR TITLE
droid-src: hybris: init: improve low memory killer thresholds

### DIFF
--- a/tagged-manifest.xml
+++ b/tagged-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <!-- incremental version bump: droid-src-sony-aosp-10/1.12.0 -->
+  <!-- incremental version bump: droid-src-sony-aosp-10/1.12.1 -->
   <remote fetch="https://github.com/mer-hybris" name="hybris"/>
   <include name="tagged-localbuild.xml"/>
-  <project name="droid-src-sony" path="rpm" remote="hybris" revision="113ac5f7c357249e9be86dede4dd692e2457e9e3"/>
+  <project name="droid-src-sony" path="rpm" remote="hybris" revision="3502b60d316ccaafe5d6d616ead8fe2d315795c1"/>
 </manifest>


### PR DESCRIPTION
Set minfree to ~7.5 times higher values: only then lmk starts killing native
Sailfish OS apps (otherwise only App Support's lmkd container is killing within,
and when there are many native apps, Android apps eventually get killed upon
launch).

~7.5-fold values have been obtained empirically. Anything lower than that will
cause to run out of swap space eventually, and lmk won't kick in as much either.

This fix should always leave around 100M of Mem+Swap available to be able to
launch big apps, not to slow system down (from too much swapping), and also to
help keeping the fingerprint running.