### PR TITLE
Update manifest

### DIFF
--- a/tagged-manifest.xml
+++ b/tagged-manifest.xml
@@ -32,7 +32,7 @@
   <project name="android_hardware_qcom_display" path="hardware/qcom/display" remote="sony-patches" revision="a7be416c0d8f383138964a84c9f8668e213b935b" upstream="droid-src-sony-aosp-8.1.0_r52_20190206"/>
   <project name="android_hardware_qcom_gps" path="hardware/qcom/gps" remote="sony-patches" revision="31fb126c9c30d20036b08c6c1663980a1e6c30f1" upstream="droid-src-sony-aosp-8.1.0_r52_20190206"/>
   <project name="android_hardware_qcom_media" path="hardware/qcom/media" remote="sony-patches" revision="ce9e3ad83a958bd3bb8c66ef4b0254fb1883d5b0" upstream="droid-src-sony-aosp-8.1.0_r52_20190206"/>
-  <project name="android_kernel_sony_msm" path="kernel/sony/msm-4.4/kernel" remote="hybris-patches" revision="651b22a24fe18a9714ec8372d5048bca10a67bd9" upstream="hybris-sony-aosp-8.1.0_r52_20190206"/>
+  <project name="android_kernel_sony_msm" path="kernel/sony/msm-4.4/kernel" remote="hybris-patches" revision="7c6ced5487e021d86c0f3d217ed4423627c8c564" upstream="hybris-sony-aosp-8.1.0_r52_20190206"/>
   <project name="android_system_core" path="system/core" remote="hybris-patches" revision="08f0e4d318051f3723adf8833b01c619124c7861" upstream="hybris-sony-aosp-8.1.0_r52_20190206"/>
   <project name="android_system_nfc" path="system/nfc" remote="sony-patches" revision="d98fb8fdcb1cb55f53560b12c2420979dd00efec" upstream="droid-src-sony-aosp-8.1.0_r52_20190206"/>
   <project name="android_system_vold" path="system/vold" remote="sony-patches" revision="a351c39be1b5148ad73e8f8e6d56b691366ba5be" upstream="droid-src-sony-aosp-8.1.0_r52_20190206"/>


### PR DESCRIPTION
[kernel] configs: Enable BNEP options in hybris defconfigs. JB#60489
[kernel] configs: Enable CONFIG_NET_DROP_MONITOR in hybris defconfigs. JB#61544